### PR TITLE
RFC1: The Mediachain Datastore

### DIFF
--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -82,7 +82,7 @@ We can make things more concrete with the following schema:
 Entity = {
  "type" : "entity"
  "name" : <String>
- [key : <Reference>]
+ ["key" : <Reference>]
  "signatures" : <Signatures>
  <Key> : <Value> ... ; entity metadata
  }
@@ -142,13 +142,16 @@ Nil = { "type" : "nil" }
 The entity and artefact chains differ on the type of relationships
 they store. They both support metadata update cells, which simply
 provide new metadata to the base object as arbitray key-value pairs.
+
 The entity chain also allows for linking two entities, for example
 having a pseudonymous artist publicly revealing a true name that
 points to another entity in the system.
+
 The artefact chain further stores links to entities that
 represent creation and potential Intellectual Property rights,
 references in the Internet media-space, and derivative relations
 to other artefacts.
+
 Each chain cell carries also carries one or more signatures by
 signatory entities in the system.
 

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -58,7 +58,7 @@ date fields.
 Artefacts can also have associated their data stored in IPFS, so that media
 can be directly accessed from references to their Canonicals.
 If this is the case, then the artefact object will contain a link to
-the IPFS datablob in its `type` field
+the IPFS datablob in its `data` field
 
 Finally, both types carry a set of cryptographic signatures that assert their
 validity. The signatures come from _signatories_ with known keys in the
@@ -109,6 +109,12 @@ through linked lists. Thus for each entity and artefact in the
 system, we also have an associated chain which initially points to the
 canonical of a global `Nil` object:
 ```
+Chain = <ChainCell> | <Nil>
+ChainCell = {
+ "type" : ...
+ "chain" : <Reference>
+ <Key> : <Value> ...
+ }
 Nil = { "type" : "nil" }
 ```
 
@@ -134,8 +140,8 @@ EntityChainCell = <EntityUpdateCell> | <Nil>
 
 EntityUpdateCell = {
  "type" : "entityUpdate"
+ "chain" : <Reference>
  "entity" : <Reference>
- "entityChain" : <Reference>
  "signatures" : <Signatures>
   <Key> : <Value> ... ; metadata updates
  }
@@ -150,16 +156,16 @@ ArtefactChainCell =
  
 ArtefactUpdateCell = {
  "type" : "artefactUpdate"
+ "chain" : <Reference>
  "artefact" : <Reference>
- "artefactChain" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; metadata updates
  }
 
 ArtefactCreationCell = {
  "type" : "artefactCreatedBy"
+ "chain" : <Reference>
  "artefact" : <Reference>
- "artefactChain" : <Reference>
  "entity" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; creation metadata
@@ -167,17 +173,17 @@ ArtefactCreationCell = {
 
 ArtefactDerivationCell = {
  "type" : "artefactDerivedBy"
+ "chain" : <Reference>
  "artefact" : <Reference>
  "artefactOrigin" : <Reference>
- "artefactChain" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; creation metadata
  }
 
 ArtefactOwnershipCell = {
  "type" : "artefactRightsOwnedBy"
+ "chain" : <Reference>
  "artefact" : <Reference>
- "artefactChain" : <Reference>
  "entity" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; IP ownership metadata
@@ -185,8 +191,8 @@ ArtefactOwnershipCell = {
 
 ArtefactReferenceCell = {
  "type" : "artefactReferencedBy"
+ "chain" : <Reference>
  "artefact" : <Reference>
- "artefactChain" : <Reference>
  "url" : <URL>
  <Key> : <Value> ... ; reference metadata
 ```

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -101,14 +101,11 @@ Reference = {
  "@link" = <Canonical>
  }
 
-Signatures = {
- "_1" : {
-  "entity" : <Reference>
-  "signature" : <IPRSSignature>
- }
- "_2" : ...
- ...
- }
+Signatures = [
+  { "entity" : <Reference>
+    "signature" : <IPRSSignature>
+  } ...
+ ]
 
 IPRSSignature = {
  "value" : <Reference>

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -24,7 +24,7 @@ Open Data Peer-to-Peer network.
 
 The Mediachain is stored in a distributed append-only datastore with
 content addressable access. This maps well to the IPFS[2] peer-to-peer
-network, which names and accesses data using the SHA256 hash of
+network, which names and accesses data using the cryptographic hashes of
 the content. Objects stored in the network are immutable and persistent;
 their hashes become their _Canonical_ identifiers through which they can
 be referenced.

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -2,7 +2,7 @@
 
 Status: DRAFT
 
-Author: @vyzo
+Author: vyzo
 
 ## Overview
 

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -35,14 +35,14 @@ CompoundValue = {
  }
 
 ```
-All Mediachain data objects have a mandatory `type` key that represents
+All Mediachain data objects have a mandatory `type` field that represents
 the data type of the object.
 Links can be embedded between data objects by using the IPLD `@link`
 special key, allowing us to construct Merkle DAGs.
 
 ### Entities and Artefacts
 
-There are two principal types of objects in the mediacain:
+There are two principal types of objects in the mediachain:
 entities and artefacts. An _Entity_ represents a person or organization
 who may associate with artefacts, for example by creating or posting
 a reference to the artefact. _Artefacts_ represent media works as tracked
@@ -52,10 +52,13 @@ common media found in the Internet.
 In the Mediachain schema, entities are instances of data objects with
 their type field set to `entity` and a mandatory `name` field.
 Artefacts are instances of data objects with their type field set
-to `artefact`, a mandatory name and an optional description and creation
-date.
+to `artefact`, a mandatory name and optional `description` and creation
+date fields.
+
 Artefacts can also have associated their data stored in IPFS, so that media
 can be directly accessed from references to their Canonicals.
+If this is the case, then the artefact object will contain a link to
+the IPFS datablob in its `type` field
 
 Finally, both types carry a set of cryptographic signatures that assert their
 validity. The signatures come from _signatories_ with known keys in the
@@ -77,9 +80,13 @@ Artefact = {
  "name" : <String>
  ["created" : <Date>]
  ["description" : <String>]
- ["data" : <IPFSReference>]
+ ["data" : <Reference>]
  "signatures" : <Signatures>
  <Key> : <Value> ... ; artefact metadata
+ }
+
+Reference = {
+ "@link" = <Canonical>
  }
 
 Signatures = {
@@ -127,8 +134,8 @@ EntityChainCell = <EntityUpdateCell> | <Nil>
 
 EntityUpdateCell = {
  "type" : "entityUpdate"
- "entity" : <EntityCanonical>
- "entityChain" : { "@link" : <EntityChainCanonical> }
+ "entity" : <Reference>
+ "entityChain" : <Reference>
  "signatures" : <Signatures>
   <Key> : <Value> ... ; metadata updates
  }
@@ -143,43 +150,43 @@ ArtefactChainCell =
  
 ArtefactUpdateCell = {
  "type" : "artefactUpdate"
- "artefact" : <ArtefactCanonical>
- "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "artefact" : <Reference>
+ "artefactChain" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; metadata updates
  }
 
 ArtefactCreationCell = {
  "type" : "artefactCreatedBy"
- "artefact" : <ArtefactCanonical>
- "artefactChain" : { "@link" : <ArtefactChainCanonical> }
- "entity" : <EntityCanonical>
+ "artefact" : <Reference>
+ "artefactChain" : <Reference>
+ "entity" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; creation metadata
  }
 
 ArtefactDerivationCell = {
  "type" : "artefactDerivedBy"
- "artefact" : <ArtefactCanonical>
- "artefactOrigin" <ArtefactCanonical> ; the origin of the derivative work
- "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "artefact" : <Reference>
+ "artefactOrigin" : <Reference>
+ "artefactChain" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; creation metadata
  }
 
 ArtefactOwnershipCell = {
  "type" : "artefactRightsOwnedBy"
- "artefact" : <ArtefactCanonical>
- "artefactChain" : { "@link" : <ArtefactChainCanonical> }
- "entity" : <EntityCanonical>
+ "artefact" : <Reference>
+ "artefactChain" : <Reference>
+ "entity" : <Reference>
  "signatures" : <Signatures>
  <Key> : <Value> ... ; IP ownership metadata
  }
 
 ArtefactReferenceCell = {
  "type" : "artefactReferencedBy"
- "artefact" : <ArtefactCanonical>
- "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "artefact" : <Reference>
+ "artefactChain" : <Reference>
  "url" : <URL>
  <Key> : <Value> ... ; reference metadata
 ```

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -1,10 +1,22 @@
 # RFC 1: The Mediachain Datastore
 
-Status: WIP
+Status: DRAFT
 
 Author: @vyzo
 
 ## Overview
+
+The Mediachain[1] is a decentralized system designed for tracking
+metadata related to Creative Works and Internet Media.
+It is being developed as an Open Source, Open Data system with
+decentralized stakeholders.
+
+This document serves as a  specification of the Mediachain data
+model and the shape of the distributed store at the heart of
+system.
+It is intended to provide a stable basis for bootstrapping the
+system from a small-scale proof of concept to a fully distributed,
+Open Data Peer-to-Peer network.
 
 ## The Mediachain Data Model
 

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -91,8 +91,13 @@ Reference = {
 
 Signatures = {
  "type" : "signatures"
- <SignatoryCanonical> : <Blob> ...
+ <SignatoryCanonical> : <IPRSSignature> ...
  }
+
+IPRSSignature = {
+ "value" : <Reference>
+ }
+
 ```
 
 ### Chains and Links
@@ -193,8 +198,10 @@ ArtefactReferenceCell = {
  "type" : "artefactReferencedBy"
  "chain" : <Reference>
  "artefact" : <Reference>
- "url" : <URL>
+ ["url" : <URL>]
+ "signatures" : <Signatures>
  <Key> : <Value> ... ; reference metadata
+  }
 ```
 
 ## Mediachain Data Access

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -74,15 +74,15 @@ the IPFS datablob in its `data` field
 
 Finally, both types carry a set of cryptographic signatures that assert their
 validity. The signatures come from _signatories_ with known keys in the
-system; any entity that contains a public key in its data can act
-as a signatory.
+system; any entity that maintains public keys in the system with a keychain
+pointer can act as a signatory.
 
 We can make things more concrete with the following schema:
 ```
 Entity = {
  "type" : "entity"
  "name" : <String>
- ["key" : <Reference>]
+ ["keychain" : <Reference>]
  "signatures" : <Signatures>
  <Key> : <Value> ... ; entity metadata
  }

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -2,7 +2,7 @@
 
 Status: DRAFT
 
-Author: vyzo
+Author: [vyzo](https://github.com/vyzo)
 
 ## Overview
 

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -323,7 +323,7 @@ Qm000... = Nil
 QmAAA... = Entity {
  "type" : "entity"
  "name" : "Hellen Green"
- "key"  : {"@link" : "QmAAABBB..."}
+ "keychain"  : {"@link" : "QmAAABBB..."}
  "platform" : "~cargocollective"
  "cargocollective_user" : "+hellengreen"
  "signatures" : {...}
@@ -350,7 +350,7 @@ QmCCC... = ArtefactCreationCell {
 QmDDD... = Entity {
  "type" : "entity"
  "name" : "Eva Tolkin"
- "key" : {"@link" : "QmDDDBBB..."}
+ "keychain" : {"@link" : "QmDDDBBB..."}
  "platform" : "~pinterest"
  "pinterest_user" : "+evatolkin"
  "signatures" : {...}
@@ -369,7 +369,7 @@ QmEEE... = ArtefactReferenceCell {
 QmFFF... = Entity {
  "type" : "entity"
  "name" : "retrofuture"
- "key" : {"@link" : "QmFFFBBB..."}
+ "keychain" : {"@link" : "QmFFFBBB..."}
  "platform" : "~tumblr"
  "tumblr_user" : "+retrofuture"
  "signatures" : {...}
@@ -405,7 +405,7 @@ QmIII... = ArtefactDerivationCell {
 QmJJJ... = Entity {
  "type" : "entity"
  "name" : "christina99"
- "key" : {"@link" : "QmJJJBBB..."}
+ "keychain" : {"@link" : "QmJJJBBB..."}
  "platform" : "~instagram"
  "instagram_user" : "+christina99"
  "signatures" : {...}

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -1,0 +1,191 @@
+# RFC 1: The Mediachain Datastore
+
+Status: WIP
+
+Author: @vyzo
+
+## Overview
+
+## The Mediachain Data Model
+
+### Data Objects
+
+The Mediachain is stored in a distributed append-only datastore with
+content addressable access. This maps well to the IPFS peer-to-peer
+network, which names and accesses data using the SHA256 hash of
+the content. Objects stored in the network are immutable and persistent;
+their hashes become their _Canonical_ identifiers through which they can
+be referenced.
+
+Mediachain objects follow the IPLD[*] data model,
+allowing for storage of key-valued pairs where keys
+are strings and values are other key-valued pairs or strings.
+
+Thus we have:
+```
+DataObject = {
+ "type" : <String>
+ <Key> : <Value>  ...
+ }
+
+Key   = <String>
+Value = <String> | <CompoundValue>
+CompoundValue = {
+ <Key> : <Value> ...
+ }
+
+```
+All Mediachain data objects have a mandatory `type` key that represents
+the data type of the object.
+Links can be embedded between data objects by using the IPLD `@link`
+special key, allowing us to construct Merkle DAGs.
+
+### Entities and Artefacts
+
+There are two principal types of objects in the mediacain:
+entities and artefacts. An _Entity_ represents a person or organization
+who may associate with artefacts, for example by creating or posting
+a reference to the artefact. _Artefacts_ represent media works as tracked
+by the Mediachain. They can be images, video, text, or any other
+common media found in the Internet. 
+
+In the Mediachain schema, entities are instances of data objects with
+their type field set to `entity` and a mandatory `name` field.
+Artefacts are instances of data objects with their type field set
+to `artefact`, a mandatory name and an optional description and creation
+date.
+Artefacts can also have associated their data stored in IPFS, so that media
+can be directly accessed from references to their Canonicals.
+
+Finally, both types carry a set of cryptographic signatures that assert their
+validity. The signatures come from _signatories_ with known keys in the
+system; any entity that contains a public key in its data can act
+as a signatory.
+
+We can make things more concrete with the following schema:
+```
+Entity = {
+ "type" : "entity"
+ "name" : <String>
+ [key : <PublicKey>]
+ "signatures" : <Signatures>
+ <Key> : <Value> ... ; entity metadata
+ }
+
+Artefact = {
+ "type" : "artefact"
+ "name" : <String>
+ ["created" : <Date>]
+ ["description" : <String>]
+ ["data" : <IPFSReference>]
+ "signatures" : <Signatures>
+ <Key> : <Value> ... ; artefact metadata
+ }
+
+Signatures = {
+ "type" : "signatures"
+ <SignatoryCanonical> : <Blob> ...
+ }
+```
+
+### Chains and Links
+
+The fundamental operation of the Mediachain is to link entities and
+artefacts with labeled relationships and metadata.  The data model
+described so far is disconnected: it contains independent entities and
+artefacts. In order to track the evolving relationships between
+entities and artefacts we need to construct chains of updates for each
+entity and artefact in the datastore.
+
+The natural way to model chains in a distributed append-only store is
+through linked lists. Thus for each entity and artefact in the
+system, we also have an associated chain which initially points to the
+canonical of a global `Nil` object:
+```
+Nil = { "type" : "nil" }
+```
+
+The entity and artefact chains differ on the type of relationships
+they store. They both support metadata update cells, which simply
+provide new metadata to the base object as arbitray key-value pairs.
+However, the artefact chain further stores links to entities that
+represent creation and potential Intellectual Property rights,
+references in the Internet media-space, and derivative relations
+to other artefacts.
+Each chain cell carries also carries one or more signatures by
+signatory entities in the system.
+
+Note that the types of cells that can appear in either type of
+chain it is not limited to the types of relationships described
+above. These are merely the minimum schema to support the
+functionality of the Mediachain.
+
+Keeping this in mind, we can model the chains with the following
+schema:
+```
+EntityChainCell = <EntityUpdateCell> | <Nil>
+
+EntityUpdateCell = {
+ "type" : "entityUpdate"
+ "entity" : <EntityCanonical>
+ "entityChain" : { "@link" : <EntityChainCanonical> }
+ "signatures" : <Signatures>
+  <Key> : <Value> ... ; metadata updates
+ }
+
+ArtefactChainCell =
+   <ArtefactUpdateCell>
+ | <ArtefactCreationCell>
+ | <ArtefactDerivationCell>
+ | <ArtefactOwnershipCell>
+ | <ArtefactReferenceCell>
+ | <Nil>
+ 
+ArtefactUpdateCell = {
+ "type" : "artefactUpdate"
+ "artefact" : <ArtefactCanonical>
+ "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "signatures" : <Signatures>
+ <Key> : <Value> ... ; metadata updates
+ }
+
+ArtefactCreationCell = {
+ "type" : "artefactCreatedBy"
+ "artefact" : <ArtefactCanonical>
+ "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "entity" : <EntityCanonical>
+ "signatures" : <Signatures>
+ <Key> : <Value> ... ; creation metadata
+ }
+
+ArtefactDerivationCell = {
+ "type" : "artefactDerivedBy"
+ "artefact" : <ArtefactCanonical>
+ "artefactOrigin" <ArtefactCanonical> ; the origin of the derivative work
+ "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "signatures" : <Signatures>
+ <Key> : <Value> ... ; creation metadata
+ }
+
+ArtefactOwnershipCell = {
+ "type" : "artefactRightsOwnedBy"
+ "artefact" : <ArtefactCanonical>
+ "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "entity" : <EntityCanonical>
+ "signatures" : <Signatures>
+ <Key> : <Value> ... ; IP ownership metadata
+ }
+
+ArtefactReferenceCell = {
+ "type" : "artefactReferencedBy"
+ "artefact" : <ArtefactCanonical>
+ "artefactChain" : { "@link" : <ArtefactChainCanonical> }
+ "url" : <URL>
+ <Key> : <Value> ... ; reference metadata
+```
+
+## Mediachain Data Access
+
+## An Example Mediachain
+
+## References

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -70,7 +70,7 @@ We can make things more concrete with the following schema:
 Entity = {
  "type" : "entity"
  "name" : <String>
- [key : <PublicKey>]
+ [key : <Reference>]
  "signatures" : <Signatures>
  <Key> : <Value> ... ; entity metadata
  }

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -247,7 +247,7 @@ CanonicalEntry = {
 ChainEntry = {
  "type"  = "update"
  "ref"   = <Reference> ; canonical reference for entity or artefact
- "chain" = <Reference>
+ "chain" = <Reference> ; head of chain for canonical reference
  }
 ```
 

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -273,14 +273,16 @@ JournalEntry =
  <ChainEntry>
 
 CanonicalEntry = {
- "type" = "insert"
- "ref"  = <Reference> ; canonical reference for an entity or artefact
+ "type" : "insert"
+ "ref"  : <Reference> ; canonical reference for an entity or artefact
+ "timestamp" : <Timestamp>
  }
  
 ChainEntry = {
- "type"  = "update"
- "ref"   = <Reference> ; canonical reference for entity or artefact
- "chain" = <Reference> ; head of chain for canonical reference
+ "type"  : "update"
+ "ref"   : <Reference> ; canonical reference for entity or artefact
+ "chain" : <Reference> ; head of chain for canonical reference
+ "timestamp" : <Timestamp>
  }
 ```
 

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -204,7 +204,68 @@ ArtefactReferenceCell = {
   }
 ```
 
-## Mediachain Data Access
+## Indexing and Querying the Mediachain
+
+### The Journal
+
+Mediachain data are persistent and available through the IPFS network.
+However they are not _discoverable_ without the help of an index which
+maintains references to entities, artefacts and chain heads.
+
+In order to make the mediachain indexable and discoverable we need to
+maintain a _Journal_ of updates to the data store. The journal is
+very similar to a blockchain in that it acts as a public ledger of all
+Mediachain data transactions in the system. By replaying the journal
+and fetching the data from IPFS, any node in the Internet can bootstrap
+an index that allows it to read and query the Mediachain.
+
+### Appending Data in the Mediachain
+
+The datastore initially is almost empty, containing only the `Nil` object
+as the bottom of all chains 
+For each entity and artefact added to the store, a corresponding entry
+is added to the journal, connecting a canonical reference with its chain
+pointing to the `Nil` object.
+Similarly, for every cell added to a chain, a corresponding entry is
+added to the journal, updating the head of the chain for a canonical
+reference.
+
+Thus the journal contents can be described as a sequence of entries
+with the following schema:
+```
+Journal = <JournalEntry> ...
+
+JournalEntry =
+ <CanonicalEntry>
+ <ChainEntry>
+
+CanonicalEntry = {
+ "type" = "insert"
+ "ref"  = <Reference> ; canonical reference for an entity or artefact
+ }
+ 
+ChainEntry = {
+ "type"  = "update"
+ "ref"   = <Reference> ; canonical reference for entity or artefact
+ "chain" = <Reference>
+ }
+```
+
+### Journal Maintenance
+
+The journal is the critical piece of metadata that connects the
+Mediachain datastore.  So far we have made no mention of how to
+maintain the Journal in a distributed fashion.
+This is purposeful: the scope of this specification is limited to
+describing the primitives of the Mediachain store in sufficient detail
+to allow bootstrap and Open Data access.
+
+The assumption is that during the system bootstrap and scaling, a
+principal entity acts as a gatekeeper responsible for the development
+of the system and maintenance of the journal.  When the system has
+been scaled out enough to warrant distribution of the write a load, a
+separate specification will address the requisite distributed
+protocols for journal maintenance and distribution.
 
 ## An Example Mediachain
 


### PR DESCRIPTION
The branch adds rfc/mediachain-rfc-1.md which contains the Mediachain Datastore specification in markdown.

Changes since last review:
DataModel:
- Cleaned up the signature and key structures to be consistent and carry references
- Added an EntityLinkCell to the entity chains so that we can have linkage between entities and support deduplication.

Structure:
- Added Overview, Example, and References sections
