### PR TITLE
transactor.Types: Add algebraic datatype for CBOR/IPLD values and some model streaminling

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,8 @@ object MediachainBuild extends Build {
     version := "0.0.1",
     scalaVersion := "2.11.7",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats" % "0.4.1"
+      "org.typelevel" %% "cats" % "0.4.1",
+      "org.json4s" %% "json4s-jackson" % "3.2.11"
     )
   )
 

--- a/transactor/build.sbt
+++ b/transactor/build.sbt
@@ -2,6 +2,5 @@ name := "transactor"
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
- "org.typelevel" %% "cats" % "0.4.1"
 )
 

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -3,7 +3,7 @@ package io.mediachain.transactor
 object Types {
   import cats.data.Xor
   
-  // Canonical|CBOR Values: IPLD datatypes
+  // Canonical Values: IPLD datatypes
   sealed abstract class CValue
   case class CString(value: String) extends CValue
   case class CMap(value: Map[String, CValue]) extends CValue
@@ -33,13 +33,17 @@ object Types {
     def chain: Option[Reference]
   }
   
-  abstract class EntityChainCell extends ChainCell {
-    def entity: Reference
-  }
+  case class EntityChainCell( 
+    entity: Reference,
+    chain: Option[Reference],
+    meta: Map[String, CValue]
+  ) extends ChainCell
   
-  abstract class ArtefactChainCell extends ChainCell {
-    def artefact: Reference
-  }
+  case class ArtefactChainCell( 
+    artefact: Reference,
+    chain: Option[Reference],
+    meta: Map[String, CValue]
+  ) extends ChainCell
   
   // Journal Entries
   abstract class JournalEntry {

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -3,32 +3,34 @@ package io.mediachain.transactor
 object Types {
   import cats.data.Xor
   
+  // Canonical|CBOR Values: IPLD datatypes
+  sealed abstract class CValue
+  case class CString(value: String) extends CValue
+  case class CMap(value: Map[String, CValue]) extends CValue
+  case class CSeq(value: Seq[CValue]) extends CValue
+
   // Mediachain Datastore Records
-  abstract class Record
+  abstract class Record {
+    def meta: Map[String, CValue]
+  }
   
   // References to records in the underlying datastore
   abstract class Reference
   
   // Canonical records: Entities and Artefacts
-  abstract class CanonicalRecord extends Record {
-    def name: String
-    def meta: Map[String, Any]
-  }
+  abstract class CanonicalRecord extends Record
   
   case class Entity(
-    name: String, 
-    meta: Map[String, Any]
+    meta: Map[String, CValue]
   ) extends CanonicalRecord
   
   case class Artefact( 
-    name: String,
-    meta: Map[String, Any]
+    meta: Map[String, CValue]
   ) extends CanonicalRecord
   
   // Chain Cells
   abstract class ChainCell extends Record {
     def chain: Option[Reference]
-    def meta: Map[String, Any]
   }
   
   abstract class EntityChainCell extends ChainCell {

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -2,16 +2,11 @@ package io.mediachain.transactor
 
 object Types {
   import cats.data.Xor
-  
-  // Canonical Values: IPLD datatypes
-  sealed abstract class CValue
-  case class CString(value: String) extends CValue
-  case class CMap(value: Map[String, CValue]) extends CValue
-  case class CSeq(value: Seq[CValue]) extends CValue
+  import org.json4s.JValue
 
   // Mediachain Datastore Records
   abstract class Record {
-    def meta: Map[String, CValue]
+    def meta: Map[String, JValue]
   }
   
   // References to records in the underlying datastore
@@ -21,11 +16,11 @@ object Types {
   abstract class CanonicalRecord extends Record
   
   case class Entity(
-    meta: Map[String, CValue]
+    meta: Map[String, JValue]
   ) extends CanonicalRecord
   
   case class Artefact( 
-    meta: Map[String, CValue]
+    meta: Map[String, JValue]
   ) extends CanonicalRecord
   
   // Chain Cells
@@ -36,13 +31,13 @@ object Types {
   case class EntityChainCell( 
     entity: Reference,
     chain: Option[Reference],
-    meta: Map[String, CValue]
+    meta: Map[String, JValue]
   ) extends ChainCell
   
   case class ArtefactChainCell( 
     artefact: Reference,
     chain: Option[Reference],
-    meta: Map[String, CValue]
+    meta: Map[String, JValue]
   ) extends ChainCell
   
   // Journal Entries


### PR DESCRIPTION
#17

Changes:
- Maps of String -> JValue for meta in Records
- Record::meta base class method
- Remove name from CanonicalRecords, field is irrelevant to the transactor
- Turn ArtefactChainCell and EntityChainCell to concrete case classes.
