### PR TITLE
Bigs WIP

### DIFF
--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -140,7 +140,7 @@ object Copycat {
     
     private def checkUpdate(ref: Reference, chain: Option[Reference],
                             xref: Reference, xchain: Option[Reference]) = {
-      (xref == ref) && ((xchain == None) || (xchain == chain))
+      (xref == ref) && (xchain.isEmpty || (xchain == chain))
     }
         
     // Snapshottable

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -17,8 +17,17 @@ object Types {
   }
   case class EntityReference(chain: Option[Reference])
     extends CanonicalReference
+
+  object EntityReference {
+    def empty: EntityReference = EntityReference(None)
+  }
+
   case class ArtefactReference(chain: Option[Reference])
     extends CanonicalReference
+
+  object ArtefactReference {
+    def empty: ArtefactReference = ArtefactReference(None)
+  }
 
   // Canonical records: Entities and Artefacts
   sealed abstract class CanonicalRecord extends Record {
@@ -28,13 +37,13 @@ object Types {
   case class Entity(
     meta: Map[String, JValue]
   ) extends CanonicalRecord {
-    def reference(): CanonicalReference = EntityReference(None)
+    def reference(): CanonicalReference = EntityReference.empty
   }
   
   case class Artefact( 
     meta: Map[String, JValue]
   ) extends CanonicalRecord {
-    def reference(): CanonicalReference = ArtefactReference(None)
+    def reference(): CanonicalReference = ArtefactReference.empty
   }
   
   // Chain Cells

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -11,17 +11,31 @@ object Types {
   
   // References to records in the underlying datastore
   abstract class Reference
-  
+
+  sealed abstract class CanonicalReference {
+    def chain: Option[Reference]
+  }
+  case class EntityReference(chain: Option[Reference])
+    extends CanonicalReference
+  case class ArtefactReference(chain: Option[Reference])
+    extends CanonicalReference
+
   // Canonical records: Entities and Artefacts
-  sealed abstract class CanonicalRecord extends Record
+  sealed abstract class CanonicalRecord extends Record {
+    def reference(): CanonicalReference
+  }
   
   case class Entity(
     meta: Map[String, JValue]
-  ) extends CanonicalRecord
+  ) extends CanonicalRecord {
+    def reference(): CanonicalReference = EntityReference(None)
+  }
   
   case class Artefact( 
     meta: Map[String, JValue]
-  ) extends CanonicalRecord
+  ) extends CanonicalRecord {
+    def reference(): CanonicalReference = ArtefactReference(None)
+  }
   
   // Chain Cells
   sealed abstract class ChainCell extends Record {


### PR DESCRIPTION
Small changes here, @vyzo. Some broader comments:
- I'm not really sure what the `CanonicalReferences` are. Are these IDs?
- With some type parameterization, we can reduce the size of `updateChain` by half i.e. have `ChainCell[T]` and `CanonicalReference[T]` where `T` can be `Artefact` or `Entity` etc
- I don't really understand the purpose of `index`. We need commenting on these types. Canonical is an overloaded term in our world -- it refers to the external identifier end users can use to refer to a work. Beyond that name clash, I'm just not sure why this was the data structure chosen. Would love to see an impl of `head` as well.

Maybe we can work out a process where I send you PRs at the end of my day
