### PR TITLE
Add circle ci config file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  java:
+    version: oraclejdk8
+  environment:
+    SBT_VERSION: 0.13.8
+    SBT_OPTS: "-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:NewRatio=8"
+dependencies:
+  cache_directories:
+    - "~/.sbt"
+  pre:
+    - wget --output-document=$HOME/bin/sbt-launch.jar https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/"$SBT_VERSION"/sbt-launch.jar
+    - echo "java $SBT_OPTS -jar \`dirname \$0\`/sbt-launch.jar \"\$@\"" > $HOME/bin/sbt
+    - chmod u+x $HOME/bin/sbt
+    - which sbt
+    - sbt sbt-version


### PR DESCRIPTION
Adds a basic circle.yml file to specify that we want oracle jdk 8.

This was copied from the L-SPACE config, but I removed the `test` section, since we haven't set up a testing framework on this project yet.
