### PR TITLE
JSON Serializers for transactor types

### DIFF
--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -2,11 +2,13 @@ package io.mediachain.transactor
 
 import java.io.File
 import java.util.function.Supplier
+
 import io.atomix.copycat.client.CopycatClient
 import io.atomix.copycat.server.{CopycatServer, StateMachine => CopycatStateMachine}
 import io.atomix.copycat.server.storage.{Storage, StorageLevel}
 import io.atomix.catalyst.transport.{Address, NettyTransport}
 import io.atomix.catalyst.serializer.Serializer
+import io.mediachain.transactor.JsonSerialization.CopycatSerializer
 
 object Copycat {
   import io.mediachain.transactor.StateMachine.JournalStateMachine
@@ -52,11 +54,11 @@ object Copycat {
 
   object Serializers {
     def register(serializer: Serializer) {
-      // XXX temporary to enable blancket use of Serializables
-      // TODO register all used classes with the serializer
-      serializer.disableWhitelist()
+      JsonSerialization.copycatSerializers.foreach { typeSerializer =>
+        serializer.register(typeSerializer.serializableClass, typeSerializer.getClass)
+      }
     }
   }
-  
-  
+
+
 }

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -4,8 +4,8 @@ import scala.collection.mutable.{Map => MMap, HashMap => MHashMap}
 
 object Dummies {
   import io.mediachain.transactor.Types._
-  
-  class DummyReference(val num: Int) extends Reference {
+
+  case class DummyReference(num: Int) extends Reference {
     override def equals(that: Any) = {
       that.isInstanceOf[DummyReference] && 
         this.num == that.asInstanceOf[DummyReference].num

--- a/transactor/src/main/scala/io/mediachain/transactor/JsonSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/JsonSerialization.scala
@@ -69,9 +69,7 @@ object JsonSerialization {
   } + referenceSerializer
 
 
-  // Below are conversion functions from transactor types to
-  // json4s `JObject`s.  We may want to write a better conversion
-  // interface/
+  // Conversion functions from transactor types to json4s `JObject`s.
 
   def toJObject(record: Record): JObject =
     Extraction.decompose(record).asInstanceOf[JObject]
@@ -84,4 +82,41 @@ object JsonSerialization {
 
   def toJObject(journalEntry: JournalEntry): JObject =
     Extraction.decompose(journalEntry).asInstanceOf[JObject]
+
+
+  /**
+    * Try to extract a value of the given type using the jsonFormats
+    * defined in this object.
+    * @param jValue the json value to extract from
+    * @param mf compiler evidence for the concrete type of the return value
+    * @tparam T type of value to return
+    * @return Some[T] on success, None on failure
+    */
+  def fromJValueOpt[T](jValue: JValue)(implicit mf: Manifest[T]): Option[T] =
+    Extraction.extractOpt(jValue)(jsonFormats, mf)
+
+  // Extraction functions for each specific type.
+  // Using a non-parametrized return type provides the implicit
+  // Manifest[T] needed by `fromJValueOpt`
+
+  def entityFromJValue(jValue: JValue): Option[Entity] =
+    fromJValueOpt(jValue)
+
+  def artefactFromJValue(jValue: JValue): Option[Artefact] =
+    fromJValueOpt(jValue)
+
+  def entityChainCellFromJValue(jValue: JValue): Option[EntityChainCell] =
+    fromJValueOpt(jValue)
+
+  def artefactChainCellFromJValue(jValue: JValue): Option[ArtefactChainCell] =
+    fromJValueOpt(jValue)
+
+  def canonicalEntryFromJValue(jValue: JValue): Option[CanonicalEntry] =
+    fromJValueOpt(jValue)
+
+  def chainEntryFromJValue(jValue: JValue): Option[CanonicalEntry] =
+    fromJValueOpt(jValue)
+
+  def ipfsReferenceFromJValue(jValue: JValue): Option[IPFSReference] =
+    fromJValueOpt(jValue)
 }

--- a/transactor/src/main/scala/io/mediachain/transactor/JsonSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/JsonSerialization.scala
@@ -1,0 +1,64 @@
+package io.mediachain.transactor
+
+import io.mediachain.transactor.Types._
+import org.json4s._
+
+case class IPLDReference(link: String) extends Reference
+
+object JsonSerialization {
+
+  /** Like json4s ShortTypeHints, but removes the outer class name for
+    * inner classes.  So instead of e.g. `Types$Artefact`, produces
+    * `Artefact`
+    */
+  private case class ShortTypeHintsIgnoreOuterClass(hints: List[Class[_]])
+    extends TypeHints {
+    def hintFor(clazz: Class[_]) =
+      clazz.getName.substring(clazz.getName.lastIndexOf(".")+1)
+        .split('$').toList.last
+
+    def classFor(hint: String) = hints find (hintFor(_) == hint)
+  }
+
+  private val shortTypeHints = ShortTypeHintsIgnoreOuterClass(List(
+    // reference
+    classOf[IPLDReference],
+
+    // canonical records
+    classOf[Entity],
+    classOf[Artefact],
+
+    // chain cells
+    classOf[EntityChainCell],
+    classOf[ArtefactChainCell],
+
+    // journal entries
+    classOf[CanonicalEntry],
+    classOf[ChainEntry]
+  ))
+
+  private val referenceSerializer = FieldSerializer[IPLDReference](
+    FieldSerializer.renameTo("link", "@link"),
+    FieldSerializer.renameFrom("@link", "link")
+  )
+
+  implicit val jsonFormats = new DefaultFormats {
+    override val dateFormat = DefaultFormats.lossless.dateFormat
+    override val typeHints = shortTypeHints
+    override val typeHintFieldName: String = "type"
+  } + referenceSerializer
+
+
+
+  def toJObject(record: Record): JObject =
+    Extraction.decompose(record).asInstanceOf[JObject]
+
+  def toJObject(chainCell: ChainCell): JObject =
+    Extraction.decompose(chainCell).asInstanceOf[JObject]
+
+  def toJObject(ref: IPLDReference): JObject =
+    Extraction.decompose(ref).asInstanceOf[JObject]
+
+  def toJObject(journalEntry: JournalEntry): JObject =
+    Extraction.decompose(journalEntry).asInstanceOf[JObject]
+}

--- a/transactor/src/main/scala/io/mediachain/transactor/JsonSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/JsonSerialization.scala
@@ -3,13 +3,22 @@ package io.mediachain.transactor
 import io.mediachain.transactor.Types._
 import org.json4s._
 
-case class IPLDReference(link: String) extends Reference
+/**
+  * Represents a 'multihash' link to an IPFS resource
+  *
+  * @param multihash - the base58 encoded string representation of an IPFS
+  *             multihash
+  */
+case class IPFSReference(multihash: String) extends Reference
 
 object JsonSerialization {
 
   /** Like json4s ShortTypeHints, but removes the outer class name for
     * inner classes.  So instead of e.g. `Types$Artefact`, produces
     * `Artefact`
+    *
+    * These hints are encoded in the `type` field of the serialized json
+    * representation.
     */
   private case class ShortTypeHintsIgnoreOuterClass(hints: List[Class[_]])
     extends TypeHints {
@@ -20,9 +29,12 @@ object JsonSerialization {
     def classFor(hint: String) = hints find (hintFor(_) == hint)
   }
 
+  /**
+    * List of classes to provide type hints for when serializing.
+    */
   private val shortTypeHints = ShortTypeHintsIgnoreOuterClass(List(
     // reference
-    classOf[IPLDReference],
+    classOf[IPFSReference],
 
     // canonical records
     classOf[Entity],
@@ -37,11 +49,19 @@ object JsonSerialization {
     classOf[ChainEntry]
   ))
 
-  private val referenceSerializer = FieldSerializer[IPLDReference](
-    FieldSerializer.renameTo("link", "@link"),
-    FieldSerializer.renameFrom("@link", "link")
+  /**
+    * Rename the `multihash` field to `@link`, to match the IPLD spec
+    */
+  private val referenceSerializer = FieldSerializer[IPFSReference](
+    FieldSerializer.renameTo("multihash", "@link"),
+    FieldSerializer.renameFrom("@link", "multihash")
   )
 
+  /**
+    * Tells json4s to use the type hints we specified, and to store them
+    * in the `type` field.  Also adds the field-renaming serializer for
+    * `IPFSReference`
+    */
   implicit val jsonFormats = new DefaultFormats {
     override val dateFormat = DefaultFormats.lossless.dateFormat
     override val typeHints = shortTypeHints
@@ -49,6 +69,9 @@ object JsonSerialization {
   } + referenceSerializer
 
 
+  // Below are conversion functions from transactor types to
+  // json4s `JObject`s.  We may want to write a better conversion
+  // interface/
 
   def toJObject(record: Record): JObject =
     Extraction.decompose(record).asInstanceOf[JObject]
@@ -56,7 +79,7 @@ object JsonSerialization {
   def toJObject(chainCell: ChainCell): JObject =
     Extraction.decompose(chainCell).asInstanceOf[JObject]
 
-  def toJObject(ref: IPLDReference): JObject =
+  def toJObject(ref: IPFSReference): JObject =
     Extraction.decompose(ref).asInstanceOf[JObject]
 
   def toJObject(journalEntry: JournalEntry): JObject =

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -5,15 +5,15 @@ object Types {
   import org.json4s.JValue
 
   // Mediachain Datastore Records
-  sealed abstract class Record extends Serializable {
+  sealed abstract class Record {
     def meta: Map[String, JValue]
   }
   
   // References to records in the underlying datastore
-  abstract class Reference extends Serializable
+  abstract class Reference
 
   // Typed References for tracking chain heads in the StateMachine
-  sealed abstract class ChainReference extends Serializable {
+  sealed abstract class ChainReference {
     def chain: Option[Reference]
   }
   


### PR DESCRIPTION
This adds a `JsonSerialization` object that contains converters to/from the transactor types and json4s `JValue`s.

It also creates copycat `TypeSerializer` classes for each serializable type, which are registered with the client and server's `Serializer`.  

At the moment the serialized json is rendered to a UTF-8 string, but we could use CBOR by pulling in the CBOR code from L-SPACE
