### PR TITLE
Add CBOR methods from L-SPACE

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,7 +10,7 @@ object MediachainBuild extends Build {
     scalaVersion := "2.11.7",
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats" % "0.4.1",
-      "org.json4s" %% "json4s-jackson" % "3.2.11"
+      "org.json4s" %% "json4s-jackson" % "3.3.0"
     )
   )
 

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborMethods.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborMethods.scala
@@ -1,0 +1,60 @@
+package io.mediachain.util.cbor
+
+import java.util.Base64
+
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.dataformat.cbor.{CBORFactory, CBORGenerator}
+import org.json4s._
+
+import scala.util.control.Exception._
+
+
+object CborMethods extends org.json4s.JsonMethods[JValue] {
+  private[this] lazy val _defaultMapper = {
+    val f = new CBORFactory()
+    f.configure(CBORGenerator.Feature.WRITE_MINIMAL_INTS, true)
+
+    val m = new ObjectMapper(f)
+    m.registerModule(new Json4sWithSortedObjectsScalaModule)
+    m
+  }
+  def mapper = _defaultMapper
+
+
+  def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): JValue = {
+    mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, useBigDecimalForDouble)
+    mapper.configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, useBigIntForLong)
+    in match {
+      case StringInput(s) =>
+        val bytes = Base64.getDecoder.decode(s)
+        mapper.readValue(bytes, classOf[JValue])
+      case ReaderInput(rdr) => mapper.readValue(rdr, classOf[JValue])
+      case StreamInput(stream) => mapper.readValue(stream, classOf[JValue])
+      case FileInput(file) => mapper.readValue(file, classOf[JValue])
+    }
+  }
+
+  def parseOpt(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): Option[JValue] =  allCatch opt {
+    parse(in, useBigDecimalForDouble, useBigIntForLong)
+  }
+
+  def render(value: JValue)(implicit formats: Formats = DefaultFormats): JValue =
+    formats.emptyValueStrategy.replaceEmpty(value)
+
+  def asJValue[T](obj: T)(implicit writer: Writer[T]): JValue = writer.write(obj)
+  def fromJValue[T](json: JValue)(implicit reader: Reader[T]): T = reader.read(json)
+
+  def asJsonNode(jv: JValue): JsonNode = mapper.valueToTree[JsonNode](jv)
+  def fromJsonNode(jn: JsonNode): JValue = mapper.treeToValue[JValue](jn, classOf[JValue])
+
+
+  def bytes(d: JValue): Array[Byte] = {
+    mapper.writeValueAsBytes(d)
+  }
+
+  def compact(d: JValue): String = {
+    Base64.getEncoder.encodeToString(bytes(d))
+  }
+
+  def pretty(d: JValue): String = compact(d)
+}

--- a/transactor/src/main/scala/io/mediachain/util/cbor/SortedObjectsSerializer.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/SortedObjectsSerializer.scala
@@ -1,0 +1,62 @@
+package io.mediachain.util.cbor
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.Module.SetupContext
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.ser.Serializers
+import org.json4s.JsonAST.JLong
+import org.json4s._
+import org.json4s.jackson.Json4sScalaModule
+
+class SortedObjectSerializer extends JsonSerializer[JValue]{
+  def serialize(value: JValue, json: JsonGenerator, provider: SerializerProvider) {
+    if (value == null) {
+      json.writeNull()
+    } else {
+      value match {
+        case JInt(v) => json.writeNumber(v.bigInteger)
+        case JLong(v) => json.writeNumber(v)
+        case JDouble(v) => json.writeNumber(v)
+        case JDecimal(v) => json.writeNumber(v.bigDecimal)
+        case JString(v) => json.writeString(v)
+        case JBool(v) => json.writeBoolean(v)
+        case JArray(elements) =>
+          json.writeStartArray()
+          elements filterNot (_ == JNothing) foreach (x => serialize(x, json, provider))
+          json.writeEndArray()
+
+        case JObject(fields) => {
+          json.writeStartObject()
+          fields sortWith { (f1, f2) =>
+            f1._1.compareTo(f2._1) < 0
+          } filterNot (_._2 == JNothing) foreach {
+            case (n, v) =>
+              json.writeFieldName(n)
+              serialize(v, json, provider)
+          }
+          json.writeEndObject()
+        }
+        case JNull => json.writeNull()
+        case JNothing => ()
+      }
+    }
+  }
+
+  override def isEmpty(value: JValue): Boolean = value == JNothing
+}
+
+private object SortedObjectSerializerResolver extends Serializers.Base {
+  private val JVALUE = classOf[JValue]
+  override def findSerializer(config: SerializationConfig, theType: JavaType, beanDesc: BeanDescription) = {
+    if (!JVALUE.isAssignableFrom(theType.getRawClass)) null
+    else new SortedObjectSerializer
+  }
+}
+
+
+class Json4sWithSortedObjectsScalaModule extends Json4sScalaModule {
+  override def setupModule(ctxt: SetupContext) {
+    super.setupModule(ctxt)
+    ctxt.addSerializers(SortedObjectSerializerResolver)
+  }
+}


### PR DESCRIPTION
This just pulls in the `CborMethods` from the L-SPACE project, and the `SortedObjectSerializer` which we use to ensure consistent ordering of map keys.

You should be able to do this:

``` scala
import io.mediachain.util.cbor.CborMethods.{bytes, render}

val cborBytes = bytes(render(someJValue))
```

to get the binary CBOR representation of any JValue.

Unfortunately, since json (and by extension, `JValue`) has no binary value type, we can't use this to store e.g. the multihash for a `@link` field as a byte array.  In theory we could special case that in the serializer, but it would be a pretty ugly hack.
