### PR TITLE
alternative CBOR encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Mediachain 💿 🔗
-The primary Mediachain repo. Contains Transactors and peer/client code. Please see [the RFC](blob/bigs-wip/rfc/mediachain-rfc-2.md) for the system design.
+The primary Mediachain repo. Contains Transactors and peer/client code. Please see [the RFC](rfc/mediachain-rfc-2.md) for the system design.

--- a/circle.yml
+++ b/circle.yml
@@ -12,4 +12,3 @@ dependencies:
     - echo "java $SBT_OPTS -jar \`dirname \$0\`/sbt-launch.jar \"\$@\"" > $HOME/bin/sbt
     - chmod u+x $HOME/bin/sbt
     - which sbt
-    - sbt sbt-version

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+script_dir=$(dirname $0)
+
+git_dir=".git"
+
+copy_hook() {
+    local from="$script_dir/$1"
+    local to="$git_dir/hooks/$2"
+    echo "Copying $from to $to" >&2
+    cp $from $to
+    chmod +x $to
+}
+
+copy_hook post-merge-checkout post-merge
+copy_hook post-merge-checkout post-checkout
+
+exit 0
+

--- a/hooks/post-merge-checkout
+++ b/hooks/post-merge-checkout
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+SCRIPT_NAME=$(basename "$0")
+
+# If run as a post-checkout script hook, and the previous and current
+# HEAD are the same or if its a file checkout, don't proceed
+if [[ "$SCRIPT_NAME" = "post-checkout" && "$1" = "$2" || "$3" = "0" ]]; then
+    exit 0
+fi
+
+echo "Checking for new or changed submodules..."
+
+# Jump to the current project's root directory (the one containing
+# .git/)
+ROOT_DIR=$(git rev-parse --show-cdup)
+
+# Finding existing submodules that have been modified
+SUBMODULES=$(grep path ${ROOT_DIR}.gitmodules | sed 's/^.*path = //')
+MOD_SUBMODULES=$(git diff --name-only --ignore-submodules=dirty | grep -F "$SUBMODULES")
+
+# Find new submodules
+NEW_SUBMODULES=$(git submodule status | egrep '^-' | cut -f2 -d' ')
+
+# If no changed submodules, exit with status code 0, else prompt the
+# user and exit accordingly
+if [[ -n "$MOD_SUBMODULES" || -n "$NEW_SUBMODULES" ]]; then
+    echo "The following submodules have been updated in HEAD:"
+    if [[ -n "$MOD_SUBMODULES" ]]; then
+        echo "$MOD_SUBMODULES"
+    fi
+    if [[ -n "$NEW_SUBMODULES" ]]; then
+        echo "$NEW_SUBMODULES"
+    fi
+    echo -n "Update submodules? [n] "
+    read -n 1 reply </dev/tty
+    echo
+    if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+        git submodule update --init --recursive
+        if grep -q protobuf <<< $MOD_SUBMODULES || grep -q protobuf <<< $NEW_SUBMODULES; then
+            echo "PB submodule updated, regenerating Scala code"
+            sbt protobuf:protobufGenerate
+        fi
+    fi
+fi

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ object MediachainBuild extends Build {
     scalacOptions ++= Seq("-Xlint", "-deprecation", "-Xfatal-warnings", "-feature"),
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats" % "0.4.1",
-      "org.json4s" %% "json4s-jackson" % "3.2.11",
+      "org.json4s" %% "json4s-jackson" % "3.3.0",
       "org.specs2" %% "specs2-core" % "3.7" % "test",
       "org.specs2" %% "specs2-junit" % "3.7" % "test",
       "org.specs2" %% "specs2-matcher-extra" % "3.7" % "test",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,10 +8,16 @@ object MediachainBuild extends Build {
     organization := "io.mediachain",
     version := "0.0.1",
     scalaVersion := "2.11.7",
+    scalacOptions ++= Seq("-Xlint", "-deprecation", "-Xfatal-warnings", "-feature"),
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats" % "0.4.1",
-      "org.json4s" %% "json4s-jackson" % "3.2.11"
-    )
+      "org.json4s" %% "json4s-jackson" % "3.2.11",
+      "org.specs2" %% "specs2-core" % "3.7" % "test",
+      "org.specs2" %% "specs2-junit" % "3.7" % "test",
+      "org.specs2" %% "specs2-matcher-extra" % "3.7" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.13.0" % "test"
+    ),
+    scalacOptions in Test ++= Seq("-Yrangepos")
   )
 
   lazy val transactor = Project("transactor", file("transactor"))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,6 +4,9 @@ import Keys._
 object MediachainBuild extends Build {
   updateOptions := updateOptions.value.withCachedResolution(true)
 
+  val specs2Version = "3.7.3"
+  val scalaCheckVersion = "1.13.1"
+
   override lazy val settings = super.settings ++ Seq(
     organization := "io.mediachain",
     version := "0.0.1",
@@ -12,10 +15,11 @@ object MediachainBuild extends Build {
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats" % "0.4.1",
       "org.json4s" %% "json4s-jackson" % "3.3.0",
-      "org.specs2" %% "specs2-core" % "3.7" % "test",
-      "org.specs2" %% "specs2-junit" % "3.7" % "test",
-      "org.specs2" %% "specs2-matcher-extra" % "3.7" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.13.0" % "test"
+      "org.specs2" %% "specs2-core" % specs2Version % "test",
+      "org.specs2" %% "specs2-junit" % specs2Version % "test",
+      "org.specs2" %% "specs2-matcher-extra" % specs2Version % "test",
+      "org.specs2" %% "specs2-scalacheck" % specs2Version % "test",
+      "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test"
     ),
     scalacOptions in Test ++= Seq("-Yrangepos")
   )

--- a/transactor/build.sbt
+++ b/transactor/build.sbt
@@ -2,10 +2,9 @@ name := "transactor"
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
-  "io.atomix.copycat" % "copycat-server" % "1.0.0-rc7",
-  "io.atomix.copycat" % "copycat-client" % "1.0.0-rc7",
-  "io.atomix.catalyst" % "catalyst-netty" % "1.0.7",
-  "org.slf4j" % "slf4j-api" % "1.7.21",
-  "org.slf4j" % "slf4j-simple" % "1.7.21",
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.4.0"
+ "io.atomix.copycat" % "copycat-server" % "1.0.0-rc7",
+ "io.atomix.copycat" % "copycat-client" % "1.0.0-rc7",
+ "io.atomix.catalyst" % "catalyst-netty" % "1.0.7",
+ "org.slf4j" % "slf4j-api" % "1.7.21",
+ "org.slf4j" % "slf4j-simple" % "1.7.21"
 )

--- a/transactor/build.sbt
+++ b/transactor/build.sbt
@@ -6,5 +6,6 @@ libraryDependencies ++= Seq(
  "io.atomix.copycat" % "copycat-client" % "1.0.0-rc7",
  "io.atomix.catalyst" % "catalyst-netty" % "1.0.7",
  "org.slf4j" % "slf4j-api" % "1.7.21",
- "org.slf4j" % "slf4j-simple" % "1.7.21"
+ "org.slf4j" % "slf4j-simple" % "1.7.21",
+ "co.nstant.in" % "cbor" % "0.7"
 )

--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -13,11 +13,12 @@ object Copycat {
   import io.mediachain.transactor.Types.Datastore
 
   object Server {
-    def build(address: Address, logdir: String, datastore: Datastore): CopycatServer = {
+    def build(address: Address, logdir: String, datastore: Datastore,
+              blocksize: Int = StateMachine.JournalBlockSize): CopycatServer = {
       def stateMachineSupplier() = {
         new Supplier[CopycatStateMachine] {
           override def get: CopycatStateMachine = {
-            new JournalStateMachine(datastore)
+            new JournalStateMachine(datastore, blocksize)
           }
         }
       }

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -14,9 +14,8 @@ object Dummies {
     override def hashCode = num
     override def toString = "dummy@" + num
 
-    val CBORType = "dummyReference"
-    override def toCbor =
-      toCMapWithDefaults(Map("@link" -> CLong(num)), Map())
+    val CBORType = "" // unused
+    override def toCbor = CMap.withStringKeys("@link" -> CString(this.toString))
   }
   
   class DummyStore extends Datastore {

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable.{Map => MMap, HashMap => MHashMap}
 
 object Dummies {
   import io.mediachain.transactor.Types._
+  import io.mediachain.util.cbor._
   
   class DummyReference(val num: Int) extends Reference {
     override def equals(that: Any) = {
@@ -12,6 +13,10 @@ object Dummies {
     }
     override def hashCode = num
     override def toString = "dummy@" + num
+
+    val CBORType = "dummyReference"
+    override def toCbor =
+      toCMapWithDefaults(Map("@link" -> CLong(num)), Map())
   }
   
   class DummyStore extends Datastore {

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable.{Map => MMap, HashMap => MHashMap}
 
 object Dummies {
   import io.mediachain.transactor.Types._
-  import io.mediachain.util.cbor._
+  import io.mediachain.util.cbor.CborAST._
   
   class DummyReference(val num: Int) extends Reference {
     override def equals(that: Any) = {

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -16,12 +16,12 @@ object Dummies {
   
   class DummyStore extends Datastore {
     var seqno = 0
-    val records: MMap[Reference, Record] = new MHashMap
+    val store: MMap[Reference, DataObject] = new MHashMap
     
-    override def put(rec: Record): Reference = {
+    override def put(obj: DataObject): Reference = {
       val ref = new DummyReference(seqno)
       seqno += 1
-      records += (ref -> rec)
+      store += (ref -> obj)
       ref
     }
   }

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -24,6 +24,8 @@ object Dummies {
       store += (ref -> obj)
       ref
     }
+    
+    def get(ref: Reference) = store.get(ref)
   }
 
 }

--- a/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
@@ -1,7 +1,8 @@
 package io.mediachain.transactor
 
 import scala.collection.mutable.{Set => MSet, HashSet => MHashSet, 
-                                 Map => MMap, HashMap => MHashMap}
+                                 Map => MMap, HashMap => MHashMap,
+                                 ListBuffer}
 
 import io.atomix.copycat.{Command, Query}
 import io.atomix.copycat.server.{Commit, StateMachine => CopycatStateMachine, Snapshottable}
@@ -25,15 +26,23 @@ object StateMachine {
   case class JournalLookup(
     ref: Reference
   ) extends Query[Option[Reference]]
+
+  case class JournalCurrentBlock() extends Query[JournalBlock]
   
-  case class JournalCommitEvent(entry: JournalEntry) extends Serializable
+  sealed abstract class JournalEvent extends Serializable
+  case class JournalCommitEvent(entry: JournalEntry) extends JournalEvent
+  case class JournalBlockEvent(ref: Reference) extends JournalEvent
 
   class JournalStateMachine(
-    val datastore: Datastore
+    val datastore: Datastore,
+    val blocksize: Int = 4096
   ) extends CopycatStateMachine with Snapshottable with SessionListener {
     private var seqno: BigInt = 0
     private var index: MMap[Reference, ChainReference] = new MHashMap // canonical -> chain map
-    private val clients: MSet[ServerSession] = new MHashSet // this wanted to be called sessions
+    private var block: ListBuffer[JournalEntry] = new ListBuffer      // current block entries
+    private var blockchain: Option[Reference] = None                  // blockchain head
+    private val clients: MSet[ServerSession] = new MHashSet           // this wanted to be called sessions
+
 
     private def commitError(what: String) = Xor.left(JournalCommitError(what))
     
@@ -56,6 +65,7 @@ object StateMachine {
 
           val entry = CanonicalEntry(nextSeqno(), ref)
           publishCommit(entry)
+          blockExtend(entry)
           Xor.right(entry)
         }
       }
@@ -73,6 +83,7 @@ object StateMachine {
       def commit(ref: Reference, newchain: Reference, oldchain: Option[Reference]) = {
         val entry = ChainEntry(nextSeqno(), ref, newchain, oldchain)
         publishCommit(entry)
+        blockExtend(entry)
         Xor.right(entry)
       }
       
@@ -111,6 +122,27 @@ object StateMachine {
         commit.release()
       }
     }
+    
+    def currentBlock(commit: Commit[JournalCurrentBlock]) : JournalBlock = {
+      try {
+        JournalBlock(seqno, blockchain, block.toList)
+      } finally {
+        commit.release()
+      }
+    }
+
+    // block generation
+    private def blockExtend(entry: JournalEntry) {
+      block += entry
+      if (block.length >= blocksize) {
+        val entries = block.toList
+        val newblock = JournalBlock(seqno, blockchain, entries)
+        val blockref = datastore.put(newblock)
+        blockchain = Some(blockref)
+        block = new ListBuffer
+        publishBlock(blockref)
+      }
+    }
 
     // helpers
     private def nextSeqno() = {
@@ -119,12 +151,15 @@ object StateMachine {
       next
     }
     
-
     private def publishCommit(entry: JournalEntry) {
       val event = JournalCommitEvent(entry)
       clients.foreach(_.publish("journal-commit", event))
     }
     
+    private def publishBlock(blockref: Reference) {
+      val event = JournalBlockEvent(blockref)
+      clients.foreach(_.publish("journal-block", event))
+    }
     
     private def checkUpdate(ref: Reference, chain: Option[Reference],
                             xref: Reference, xchain: Option[Reference]) = {
@@ -135,11 +170,15 @@ object StateMachine {
     override def install(reader: SnapshotReader) {
       seqno = reader.readObject()
       index = reader.readObject()
+      block = reader.readObject()
+      blockchain = reader.readObject()
     }
     
     override def snapshot(writer: SnapshotWriter) {
       writer.writeObject(seqno)
       writer.writeObject(index)
+      writer.writeObject(block)
+      writer.writeObject(blockchain)
     }
     
     // Session Listener

--- a/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
@@ -126,7 +126,7 @@ object StateMachine {
     
     def currentBlock(commit: Commit[JournalCurrentBlock]) : JournalBlock = {
       try {
-        JournalBlock(seqno, blockchain, block.toList)
+        JournalBlock(seqno, blockchain, block.toArray)
       } finally {
         commit.release()
       }
@@ -136,7 +136,7 @@ object StateMachine {
     private def blockExtend(entry: JournalEntry) {
       block += entry
       if (block.length >= JournalBlockSize) {
-        val entries = block.toList
+        val entries = block.toArray
         val newblock = JournalBlock(seqno, blockchain, entries)
         val blockref = datastore.put(newblock)
         blockchain = Some(blockref)

--- a/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
@@ -36,7 +36,8 @@ object StateMachine {
   case class JournalBlockEvent(ref: Reference) extends JournalEvent
 
   class JournalStateMachine(
-    val datastore: Datastore
+    val datastore: Datastore,
+    val blocksize: Int = JournalBlockSize // configurable to facilitate testing
   ) extends CopycatStateMachine with Snapshottable with SessionListener {
     private var seqno: BigInt = 0
     private var index: MMap[Reference, ChainReference] = new MHashMap // canonical -> chain map
@@ -135,7 +136,7 @@ object StateMachine {
     // block generation
     private def blockExtend(entry: JournalEntry) {
       block += entry
-      if (block.length >= JournalBlockSize) {
+      if (block.length >= blocksize) {
         val entries = block.toArray
         val newblock = JournalBlock(seqno, blockchain, entries)
         val blockref = datastore.put(newblock)

--- a/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
@@ -1,0 +1,164 @@
+package io.mediachain.transactor
+
+import io.mediachain.transactor.Dummies.DummyReference
+
+
+object TypeSerialization {
+
+  import cats.data.Xor
+  import io.mediachain.transactor.Types._
+  import io.mediachain.util.cbor.CborAST._
+  import io.mediachain.util.cbor.CborCodec
+
+  object CBORTypeNames {
+    val Entity = "entity"
+    val Artefact = "artefact"
+    val EntityChainReference = "entityChainReference"
+    val ArtefactChainReference = "artefactChainReference"
+    val EntityChainCell = "entityChainCell"
+    val ArtefactChainCell = "artefactChainCell"
+    val CanonicalEntry = "insert"
+    val ChainEntry = "update"
+    val JournalBlock = "journalBlock"
+  }
+
+  sealed trait DeserializationError
+
+  case class CborDecodingFailed() extends DeserializationError
+
+  case class UnexpectedCborType(message: String) extends DeserializationError
+
+  case class ReferenceDecodingFailed(message: String) extends DeserializationError
+
+  case class TypeNameNotFound() extends DeserializationError
+
+  case class UnknownDataObjectType(typeName: String) extends DeserializationError
+
+  case class RequiredFieldNotFound(fieldName: String) extends DeserializationError
+
+  def fromCborBytes(bytes: Array[Byte]): Xor[DeserializationError, DataObject] =
+    CborCodec.decode(bytes) match {
+      case (cValue: CValue) :: _ => fromCbor(cValue)
+      case Nil => Xor.left(CborDecodingFailed())
+    }
+
+  def fromCbor(cValue: CValue): Xor[DeserializationError, DataObject] =
+    cValue match {
+      case (cMap: CMap) => fromCMap(cMap)
+      case _ => Xor.left(UnexpectedCborType(
+        s"Expected CBOR map, but received ${cValue.getClass.getName}"
+      ))
+    }
+
+  def fromCMap(cMap: CMap): Xor[DeserializationError, DataObject] = {
+    val typeNameOpt: Option[String] =
+      cMap.getAs[CString]("type").map(_.string)
+
+    Xor.fromOption(typeNameOpt, TypeNameNotFound())
+      .flatMap(name => fromCMap(cMap, name))
+  }
+
+
+
+  def fromCMap(cMap: CMap, typeName: String)
+  : Xor[DeserializationError, DataObject] = typeName match {
+      case CBORTypeNames.Entity =>
+        Xor.right(Entity(meta = cMap.asStringKeyedMap - "type"))
+
+      case CBORTypeNames.Artefact =>
+        Xor.right(Artefact(meta = cMap.asStringKeyedMap - "type"))
+
+      case CBORTypeNames.EntityChainCell =>
+        entityChainCellFromCMap(cMap)
+
+      case CBORTypeNames.ArtefactChainCell =>
+        artefactChainCellFromCMap(cMap)
+
+      case _ => Xor.left(UnknownDataObjectType(typeName))
+    }
+
+
+  def entityChainCellFromCMap(cMap: CMap)
+  : Xor[DeserializationError, EntityChainCell] = {
+    val entityXor = getRequiredReference(cMap, "entity")
+    entityXor.map { entityRef: Reference =>
+      EntityChainCell(
+        entity = entityRef,
+        chain = getOptionalReference(cMap, "chain"),
+        meta = cMap.asStringKeyedMap -- Seq("type", "entity", "chain")
+      )
+    }
+  }
+
+  def artefactChainCellFromCMap(cMap: CMap)
+  : Xor[DeserializationError, ArtefactChainCell] = {
+    val artefactXor = getRequiredReference(cMap, "artefact")
+    artefactXor.map { artefactRef: Reference =>
+      ArtefactChainCell(
+        artefact = artefactRef,
+        chain = getOptionalReference(cMap, "chain"),
+        meta = cMap.asStringKeyedMap -- Seq("type", "artefact", "chain")
+      )
+    }
+  }
+
+
+  def canonicalEntryFromCMap(cMap: CMap)
+  : Xor[DeserializationError, CanonicalEntry] =
+    for {
+      index <- getRequired[CInt](cMap, "index").map(_.num)
+      ref <- getRequiredReference(cMap, "ref")
+    } yield CanonicalEntry(index, ref)
+
+
+  def chainEntryFromCMap(cMap: CMap)
+  : Xor[DeserializationError, ChainEntry] =
+    for {
+      index <- getRequired[CInt](cMap, "index").map(_.num)
+      ref <- getRequiredReference(cMap, "ref")
+      chain <- getRequiredReference(cMap, "chain")
+    } yield ChainEntry(
+      index = index,
+      ref = ref,
+      chain = chain,
+      chainPrevious = getOptionalReference(cMap, "chainPrevious")
+    )
+
+  def getRequired[T <: CValue](cMap: CMap, fieldName: String)
+  : Xor[RequiredFieldNotFound, T] = Xor.fromOption(
+    cMap.getAs[T](fieldName),
+    RequiredFieldNotFound(fieldName)
+  )
+
+
+  def getRequiredReference(cMap: CMap, fieldName: String)
+  : Xor[DeserializationError, Reference] =
+    getRequired[CMap](cMap, fieldName)
+    .flatMap(referenceFromCMap)
+
+
+  def getOptionalReference(cMap: CMap, fieldName: String): Option[Reference] =
+    cMap.getAs[CMap](fieldName)
+      .flatMap(referenceFromCMap(_).toOption)
+
+
+
+  def referenceFromCMap(cMap: CMap): Xor[DeserializationError, Reference] = {
+    val linkOpt: Option[CValue] =
+      cMap.asStringKeyedMap.get("@link")
+
+    Xor.fromOption(linkOpt, ReferenceDecodingFailed("@link field not found"))
+      .flatMap(decodeLinkValue)
+  }
+
+
+  def decodeLinkValue(linkVal: CValue): Xor[DeserializationError, Reference] =
+    linkVal match {
+      case CString(s) if s.startsWith("dummy@") => {
+        val seqno = s.substring("dummy@".length).toInt
+        Xor.right(new DummyReference(seqno))
+      }
+      case _ =>
+        Xor.left(ReferenceDecodingFailed(s"Unknown link value $linkVal"))
+    }
+}

--- a/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
@@ -55,7 +55,7 @@ object TypeSerialization {
       case Xor.Right(journalEntry: JournalEntry) => Xor.right(journalEntry)
       case Xor.Right(unknownObject) =>
         Xor.left(UnexpectedCborType(
-          s"Expected DataObject, but got ${unknownObject.getClass.getTypeName}"
+          s"Expected JournalEntry, but got ${unknownObject.getClass.getTypeName}"
         ))
     }
 

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -4,7 +4,8 @@ package io.mediachain.transactor
 object Types {
   import cats.data.Xor
 
-  import io.mediachain.util.cbor._
+  import io.mediachain.util.cbor.CborCodec
+  import io.mediachain.util.cbor.CborAST._
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable with ToCbor
@@ -12,7 +13,7 @@ object Types {
   trait ToCbor {
     val CBORType: String
 
-    def toCborBytes: Array[Byte] = encode(toCbor)
+    def toCborBytes: Array[Byte] = CborCodec.encode(toCbor)
 
     def toCbor: CValue =
       toCMapWithDefaults(Map.empty, Map.empty)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -10,9 +10,9 @@ object Types {
   import io.mediachain.util.cbor.CborAST._
 
   // Base class of all objects storable in the Datastore
-  sealed abstract class DataObject extends Serializable with ToCbor
+  sealed abstract class DataObject extends Serializable with CborSerializable
 
-  trait ToCbor {
+  trait CborSerializable {
     val CBORType: String
 
     def toCborBytes: Array[Byte] = CborCodec.encode(toCbor)
@@ -39,10 +39,10 @@ object Types {
   }
 
   // References to records in the underlying datastore
-  abstract class Reference extends Serializable with ToCbor
+  abstract class Reference extends Serializable with CborSerializable
 
   // Typed References for tracking chain heads in the StateMachine
-  sealed abstract class ChainReference extends Serializable with ToCbor {
+  sealed abstract class ChainReference extends Serializable with CborSerializable {
     def chain: Option[Reference]
 
     override def toCbor =
@@ -126,8 +126,7 @@ object Types {
   }
   
   // Journal Entries
-  sealed abstract class JournalEntry extends DataObject
-    with Serializable with ToCbor {
+  sealed abstract class JournalEntry extends Serializable with CborSerializable {
     def index: BigInt
     def ref: Reference
   }

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -26,7 +26,7 @@ object Types {
       }
       val withType = ("type", CString(CBORType)) :: merged.toList
 
-      CMap(withType)
+      CMap.withStringKeys(withType)
     }
   }
 

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,5 +1,7 @@
 package io.mediachain.transactor
 
+import io.mediachain.transactor.TypeSerialization.CBORTypeNames
+
 
 object Types {
   import cats.data.Xor
@@ -49,7 +51,7 @@ object Types {
 
   case class EntityChainReference(chain: Option[Reference])
     extends ChainReference {
-    val CBORType = "entityChainReference"
+    val CBORType = CBORTypeNames.EntityChainReference
   }
 
   object EntityChainReference {
@@ -58,7 +60,7 @@ object Types {
 
   case class ArtefactChainReference(chain: Option[Reference])
     extends ChainReference {
-    val CBORType = "artefactChainReference"
+    val CBORType = CBORTypeNames.ArtefactChainReference
   }
 
   object ArtefactChainReference {
@@ -73,7 +75,7 @@ object Types {
   case class Entity(
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = "entity"
+    val CBORType = CBORTypeNames.Entity
     override def toCbor =
       super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
 
@@ -83,7 +85,7 @@ object Types {
   case class Artefact( 
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = "entity"
+    val CBORType = CBORTypeNames.Artefact
     override def toCbor =
       super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
     
@@ -100,7 +102,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = "entityChainCell"
+    val CBORType = CBORTypeNames.EntityChainCell
 
     override def toCbor = {
       val defaults = meta + ("entity" -> entity.toCbor)
@@ -114,7 +116,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = "artefactChainCell"
+    val CBORType = CBORTypeNames.ArtefactChainCell
 
     override def toCbor = {
       val defaults = meta + ("artefact" -> artefact.toCbor)
@@ -133,7 +135,7 @@ object Types {
     index: BigInt,
     ref: Reference
   ) extends JournalEntry {
-    val CBORType = "insert"
+    val CBORType = CBORTypeNames.CanonicalEntry
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -151,7 +153,7 @@ object Types {
     chain: Reference,
     chainPrevious: Option[Reference]
   ) extends JournalEntry {
-    val CBORType = "update"
+    val CBORType = CBORTypeNames.ChainEntry
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -172,7 +174,7 @@ object Types {
     chain: Option[Reference],
     entries: Array[JournalEntry]
   ) extends DataObject {
-    val CBORType = "journalBlock"
+    val CBORType = CBORTypeNames.JournalBlock
 
     override def toCbor = {
       val cborEntries = CArray(entries.map(_.toCbor).toList)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -36,7 +36,7 @@ object Types {
   }
 
   // References to records in the underlying datastore
-  abstract class Reference extends Serializable
+  abstract class Reference extends Serializable with ToCbor
 
   // Typed References for tracking chain heads in the StateMachine
   sealed abstract class ChainReference extends Serializable {
@@ -106,7 +106,7 @@ object Types {
     override def toCbor: CValue = {
       val defaults = Map(
         "index" -> CInt(index),
-        "ref"   -> CString(ref.toString)
+        "ref"   -> ref.toCbor
       )
       super.toCMapWithDefaults(defaults, Map())
     }
@@ -124,10 +124,10 @@ object Types {
     override def toCbor: CValue = {
       val defaults = Map(
         "index" -> CInt(index),
-        "ref"   -> CString(ref.toString),
-        "chain" -> CString(chain.toString)
+        "ref"   -> ref.toCbor,
+        "chain" -> chain.toCbor
       )
-      val prev = chainPrevious.map(x => CString(x.toString))
+      val prev = chainPrevious.map(_.toCbor)
       val optionals = Map("chainPrevious" -> prev)
 
       super.toCMapWithDefaults(defaults, optionals)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -126,7 +126,8 @@ object Types {
   }
   
   // Journal Entries
-  sealed abstract class JournalEntry extends Serializable with ToCbor {
+  sealed abstract class JournalEntry extends DataObject
+    with Serializable with ToCbor {
     def index: BigInt
     def ref: Reference
   }

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -90,7 +90,7 @@ object Types {
   case class JournalBlock(
     index: BigInt,
     chain: Option[Reference],
-    entries: Seq[JournalEntry]
+    entries: Array[JournalEntry]
   ) extends DataObject
   
   // Journal transactor interface

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,5 +1,8 @@
 package io.mediachain.transactor
 
+import java.io.ByteArrayOutputStream
+
+
 object Types {
   import cats.data.Xor
 
@@ -8,9 +11,21 @@ object Types {
   sealed abstract class DataObject extends Serializable
 
   import org.json4s.{JValue, JObject, JString, JField}
+  import co.nstant.in.cbor.{model => Cbor}
+  import co.nstant.in.cbor.CborEncoder
+  import io.mediachain.util.cbor.JValueConversions.jValueToCbor
 
   trait ToJObject {
     val CBORType: String
+
+    def toCbor: Cbor.DataItem = jValueToCbor(toJObject)
+
+    def toCborBytes: Array[Byte] = {
+      val out = new ByteArrayOutputStream()
+      new CborEncoder(out).encode(toCbor)
+      out.close()
+      out.toByteArray
+    }
 
     def toJObject: JObject =
       toJObjectWithDefaults(Map.empty, Map.empty)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,31 +1,21 @@
 package io.mediachain.transactor
 
-import java.io.ByteArrayOutputStream
-
 
 object Types {
   import cats.data.Xor
 
+  import io.mediachain.util.cbor._
+  import org.json4s.{JValue, JObject, JString}
+  import io.mediachain.util.cbor.JValueConversions.jValueToCbor
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable
 
-  import org.json4s.{JValue, JObject, JString, JField}
-  import co.nstant.in.cbor.{model => Cbor}
-  import co.nstant.in.cbor.CborEncoder
-  import io.mediachain.util.cbor.JValueConversions.jValueToCbor
-
   trait ToJObject {
     val CBORType: String
 
-    def toCbor: Cbor.DataItem = jValueToCbor(toJObject)
-
-    def toCborBytes: Array[Byte] = {
-      val out = new ByteArrayOutputStream()
-      new CborEncoder(out).encode(toCbor)
-      out.close()
-      out.toByteArray
-    }
+    def toCbor: CValue = jValueToCbor(toJObject)
+    def toCborBytes: Array[Byte] = encode(toCbor)
 
     def toJObject: JObject =
       toJObjectWithDefaults(Map.empty, Map.empty)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,32 +1,8 @@
 package io.mediachain.transactor
 
-
 object Types {
   import cats.data.Xor
-  import org.json4s.{JValue, JObject, JString, JField}
-
-  trait ToJObject {
-    val CBORType: String
-    val meta: Map[String, JValue]
-
-    def toJObject: JObject =
-      toJObjectWithDefaults(Map.empty, Map.empty)
-
-    def toJObjectWithDefaults(defaults: Map[String, JValue],
-                              optionals: Map[String, Option[JValue]]):
-    JObject = {
-      val defaultsWithOptionals = defaults ++ optionals.flatMap {
-        case (_, None) => List.empty
-        case (k, Some(v)) => List(k -> v)
-      }
-      val merged = defaultsWithOptionals.foldLeft(meta) {
-        (m, x) => m + x
-      }
-      val withType = ("type", JString(CBORType)) :: merged.toList
-
-      JObject(withType)
-    }
-  }
+  import org.json4s.JValue
 
   // Mediachain Datastore Records
   sealed abstract class Record extends Serializable {
@@ -61,36 +37,15 @@ object Types {
   }
   
   case class Entity(
-    name: JString,
     meta: Map[String, JValue]
-  ) extends CanonicalRecord with ToJObject {
-    val CBORType = "entity"
-
+  ) extends CanonicalRecord {
     def reference: ChainReference = EntityChainReference.empty
-
-    override def toJObject: JObject = {
-      val defaults = Map("name" -> name)
-      super.toJObjectWithDefaults(defaults, Map())
-    }
-
   }
   
-  case class Artefact(
-    name: JString,
-    created: Option[JString],
-    description: Option[JString],
+  case class Artefact( 
     meta: Map[String, JValue]
-  ) extends CanonicalRecord with ToJObject {
-    val CBORType = "entity"
-
+  ) extends CanonicalRecord {
     def reference: ChainReference = ArtefactChainReference.empty
-
-    override def toJObject: JObject = {
-      val defaults = Map("name" -> name)
-      val optionals = Map("created" -> created, "description" -> description)
-
-      super.toJObjectWithDefaults(defaults, optionals)
-    }
   }
   
   // Chain Cells

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -2,10 +2,31 @@ package io.mediachain.transactor
 
 object Types {
   import cats.data.Xor
-  import org.json4s.JValue
+
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable
+
+  import org.json4s.{JValue, JObject, JString, JField}
+
+  trait ToJObject {
+    val CBORType: String
+
+    def toJObject: JObject =
+      toJObjectWithDefaults(Map.empty, Map.empty)
+
+    def toJObjectWithDefaults(defaults: Map[String, JValue],
+                              optionals: Map[String, Option[JValue]]):
+    JObject = {
+      val merged = defaults ++ optionals.flatMap {
+        case (_, None) => List.empty
+        case (k, Some(v)) => List(k -> v)
+      }
+      val withType = ("type", JString(CBORType)) :: merged.toList
+
+      JObject(withType)
+    }
+  }
 
   // Mediachain Datastore Records
   sealed abstract class Record extends DataObject {

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -1,15 +1,12 @@
-package io.mediachain.util
+package io.mediachain.util.cbor
 
 
-package object cbor {
-  import java.io.ByteArrayOutputStream
-
+object CborAST {
   import co.nstant.in.cbor.builder.AbstractBuilder
   import co.nstant.in.cbor.model.SimpleValueType
-  import co.nstant.in.cbor.{CborDecoder, CborEncoder, model => Cbor}
+  import co.nstant.in.cbor.{model => Cbor}
 
   import collection.JavaConverters._
-
 
   sealed trait CValue
   case class CNull() extends CValue
@@ -96,16 +93,6 @@ package object cbor {
 
     case _ => CUnhandled(item)
   }
-
-  def encode(cValue: CValue): Array[Byte] = {
-    val out = new ByteArrayOutputStream
-    new CborEncoder(out).encode(toDataItem(cValue))
-    out.close()
-    out.toByteArray
-  }
-
-  def decode(bytes: Array[Byte]): List[CValue] =
-    CborDecoder.decode(bytes).asScala.map(fromDataItem).toList
 
 
   private val converter = new DataItemConverter

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -15,7 +15,6 @@ object CborAST {
   case class CNull() extends CValue
   case class CUndefined() extends CValue
   case class CInt(num: BigInt) extends CValue
-  case class CLong(num: Long) extends CValue
   case class CDouble(num: Double) extends CValue
   case class CBool(bool: Boolean) extends CValue
   case class CString(string: String) extends CValue
@@ -65,7 +64,6 @@ object CborAST {
     case _: CNull => Cbor.SimpleValue.NULL
     case _: CUndefined => Cbor.SimpleValue.UNDEFINED
     case CInt(num) => converter.convert(num)
-    case CLong(num) => converter.convert(num)
     case CDouble(num) => converter.convert(num)
     case CBool(bool) => converter.convert(bool)
     case CString(string) => converter.convert(string)
@@ -88,6 +86,11 @@ object CborAST {
   }
 
   def fromDataItem(item: Cbor.DataItem): CValue = item match {
+      // match these first, since they're encoded as Arrays and would
+      // otherwise match CArray
+    case _: Cbor.LanguageTaggedString => CUnhandled(item)
+    case _: Cbor.RationalNumber => CUnhandled(item)
+
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.TRUE =>
       CBool(true)
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.FALSE =>

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -28,11 +28,16 @@ object CborAST {
 
 
   object CMap {
+    def apply(fields: CField*): CMap = CMap(fields.toList)
+
     // would like to have used `apply` here, but thanks to type erasure
     // the JVM can't distinguish between a List[(CValue, CValue)] and a
     // List[(String, CValue)]
     def withStringKeys(stringFields: List[(String, CValue)]): CMap =
       CMap(stringFields.map(f => (CString(f._1), f._2)))
+
+    def withStringKeys(stringFields: (String, CValue)*): CMap =
+      withStringKeys(stringFields.toList)
   }
 
   def toDataItem(cValue: CValue): Cbor.DataItem = cValue match {

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborCodec.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborCodec.scala
@@ -1,0 +1,18 @@
+package io.mediachain.util.cbor
+
+object CborCodec {
+  import java.io.ByteArrayOutputStream
+  import co.nstant.in.cbor.{CborDecoder, CborEncoder}
+  import io.mediachain.util.cbor.CborAST._
+  import collection.JavaConverters._
+
+  def encode(cValue: CValue): Array[Byte] = {
+    val out = new ByteArrayOutputStream
+    new CborEncoder(out).encode(CborAST.toDataItem(cValue))
+    out.close()
+    out.toByteArray
+  }
+
+  def decode(bytes: Array[Byte]): List[CValue] =
+    CborDecoder.decode(bytes).asScala.map(CborAST.fromDataItem).toList
+}

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -4,7 +4,7 @@ package io.mediachain.util.cbor
 
 object JValueConversions {
   import org.json4s._
-
+  import io.mediachain.util.cbor.CborAST._
 
   def jValueToCbor(jValue: JValue): CValue = {
     jValue match {

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -46,14 +46,13 @@ object JValueConversions {
       }
 
       case JObject(fields) => {
-        val cborFields = fields.map { pair: (String, JValue) =>
-          val cborVal = jValueToCbor(pair._2)
-          val name = new Cbor.UnicodeString(pair._1)
-          (name, cborVal)
+        val cborMap = new Cbor.Map(fields.length)
+        fields.foreach { f: JField =>
+          cborMap.put(
+            new Cbor.UnicodeString(f._1),
+            jValueToCbor(f._2)
+          )
         }
-
-        val cborMap = new Cbor.Map(cborFields.length)
-        cborFields.foreach(f => cborMap.put(f._1, f._2))
         cborMap
       }
 

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -1,10 +1,10 @@
 package io.mediachain.util.cbor
 
-import co.nstant.in.cbor.CborBuilder
-import co.nstant.in.cbor.{model => Cbor}
-import org.json4s._
 
 object JValueConversions {
+  import co.nstant.in.cbor.CborBuilder
+  import co.nstant.in.cbor.{model => Cbor}
+  import org.json4s._
   import collection.JavaConverters._
 
   private def firstItem(builder: CborBuilder): Cbor.DataItem =

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -11,7 +11,7 @@ object JValueConversions {
       case JNull => CNull()
       case JNothing => CUndefined()
       case JInt(num) => CInt(num)
-      case JLong(num) => CLong(num)
+      case JLong(num) => CInt(num)
       case JDecimal(num) => CDouble(num.doubleValue)
       case JDouble(num) => CDouble(num)
       case JBool(b) => CBool(b)

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -1,50 +1,23 @@
 package io.mediachain.util.cbor
 
 
+
 object JValueConversions {
-  import co.nstant.in.cbor.builder.AbstractBuilder
-  import co.nstant.in.cbor.{model => Cbor}
   import org.json4s._
 
-  // Provides access to protected `convert` methods on `AbstractBuilder`
-  private class StatelessBuilder extends AbstractBuilder[Object](null) {
-    def convertNumber(num: BigInt) = super.convert(num.bigInteger)
-    def convertNumber(num: BigDecimal) = super.convert(num.doubleValue)
-    def convertNumber(num: Long) = super.convert(num)
-    def convertNumber(num: Double) = super.convert(num)
-    def convertBool(boolean: Boolean) = super.convert(boolean)
-    def convertString(string: String) = super.convert(string)
-  }
 
-
-  def jValueToCbor(jValue: JValue): Cbor.DataItem = {
-    val builder = new StatelessBuilder
+  def jValueToCbor(jValue: JValue): CValue = {
     jValue match {
-      case JNull => Cbor.SimpleValue.NULL
-      case JNothing => Cbor.SimpleValue.UNDEFINED
-      case JInt(num) => builder.convertNumber(num)
-      case JLong(num) => builder.convertNumber(num)
-      case JDecimal(num) => builder.convertNumber(num)
-      case JDouble(num) => builder.convertNumber(num)
-      case JBool(b) => builder.convertBool(b)
-      case JString(s) => builder.convertString(s)
-
-      case JArray(arr) => {
-        val cborArr = new Cbor.Array(arr.length)
-        arr.foreach(jValue => cborArr.add(jValueToCbor(jValue)))
-        cborArr
-      }
-
-      case JObject(fields) => {
-        val cborMap = new Cbor.Map(fields.length)
-        fields.foreach { f: JField =>
-          cborMap.put(
-            builder.convertString(f._1),
-            jValueToCbor(f._2)
-          )
-        }
-        cborMap
-      }
+      case JNull => CNull()
+      case JNothing => CUndefined()
+      case JInt(num) => CInt(num)
+      case JLong(num) => CLong(num)
+      case JDecimal(num) => CDouble(num.doubleValue)
+      case JDouble(num) => CDouble(num)
+      case JBool(b) => CBool(b)
+      case JString(s) => CString(s)
+      case JArray(arr) => CArray(arr.map(jValueToCbor))
+      case JObject(fields) => CMap(fields.map(f => (f._1, jValueToCbor(f._2))))
     }
   }
 }

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -1,0 +1,64 @@
+package io.mediachain.util.cbor
+
+import co.nstant.in.cbor.CborBuilder
+import co.nstant.in.cbor.{model => Cbor}
+import org.json4s._
+
+object JValueConversions {
+  import scala.language.implicitConversions
+  import collection.JavaConverters._
+
+  private def firstItem(builder: CborBuilder): Cbor.DataItem =
+    builder.build().asScala.headOption.getOrElse {
+    throw new MappingException("Unable to convert JValue to CBOR")
+  }
+
+  implicit def jValueToCbor(jValue: JValue): Cbor.DataItem =
+    jValue match {
+      case JInt(num) => firstItem {
+        new CborBuilder().add(num.bigInteger)
+      }
+
+      case JLong(num) => firstItem {
+        new CborBuilder().add(num)
+      }
+
+      case JDecimal(num) => firstItem {
+        new CborBuilder().add(num.doubleValue())
+      }
+
+      case JDouble(num) => firstItem {
+        new CborBuilder().add(num)
+      }
+
+      case JBool(b) => firstItem {
+        new CborBuilder().add(b)
+      }
+
+      case JString(s) => firstItem {
+        new CborBuilder().add(s)
+      }
+
+      case JArray(arr) => {
+        val cborValues = arr.map(jValueToCbor)
+        val cborArr = new Cbor.Array(cborValues.length)
+        cborValues.foreach(cborArr.add)
+        cborArr
+      }
+
+      case JObject(fields) => {
+        val cborFields = fields.map { pair: (String, JValue) =>
+          val cborVal = jValueToCbor(pair._2)
+          val name = new Cbor.UnicodeString(pair._1)
+          (name, cborVal)
+        }
+
+        val cborMap = new Cbor.Map(cborFields.length)
+        cborFields.foreach(f => cborMap.put(f._1, f._2))
+        cborMap
+      }
+
+      case JNull => Cbor.SimpleValue.NULL
+      case JNothing => Cbor.SimpleValue.UNDEFINED
+    }
+}

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -7,36 +7,32 @@ object JValueConversions {
   import org.json4s._
   import collection.JavaConverters._
 
-  private def firstItem(builder: CborBuilder): Cbor.DataItem =
-    builder.build().asScala.headOption.getOrElse {
-    throw new MappingException("Unable to convert JValue to CBOR")
+  private implicit class BuilderHead(builder: CborBuilder) {
+    def head: Cbor.DataItem =
+      builder.build().asScala.headOption.getOrElse {
+        throw new MappingException("Unable to convert JValue to CBOR")
+      }
   }
 
   def jValueToCbor(jValue: JValue): Cbor.DataItem =
     jValue match {
-      case JInt(num) => firstItem {
-        new CborBuilder().add(num.bigInteger)
-      }
+      case JInt(num) =>
+        new CborBuilder().add(num.bigInteger).head
 
-      case JLong(num) => firstItem {
-        new CborBuilder().add(num)
-      }
+      case JLong(num) =>
+        new CborBuilder().add(num).head
 
-      case JDecimal(num) => firstItem {
-        new CborBuilder().add(num.doubleValue())
-      }
+      case JDecimal(num) =>
+        new CborBuilder().add(num.doubleValue).head
 
-      case JDouble(num) => firstItem {
-        new CborBuilder().add(num)
-      }
+      case JDouble(num) =>
+        new CborBuilder().add(num).head
 
-      case JBool(b) => firstItem {
-        new CborBuilder().add(b)
-      }
+      case JBool(b) =>
+        new CborBuilder().add(b).head
 
-      case JString(s) => firstItem {
-        new CborBuilder().add(s)
-      }
+      case JString(s) =>
+        new CborBuilder().add(s).head
 
       case JArray(arr) => {
         val cborValues = arr.map(jValueToCbor)
@@ -57,6 +53,7 @@ object JValueConversions {
       }
 
       case JNull => Cbor.SimpleValue.NULL
+
       case JNothing => Cbor.SimpleValue.UNDEFINED
     }
 }

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -5,7 +5,6 @@ import co.nstant.in.cbor.{model => Cbor}
 import org.json4s._
 
 object JValueConversions {
-  import scala.language.implicitConversions
   import collection.JavaConverters._
 
   private def firstItem(builder: CborBuilder): Cbor.DataItem =
@@ -13,7 +12,7 @@ object JValueConversions {
     throw new MappingException("Unable to convert JValue to CBOR")
   }
 
-  implicit def jValueToCbor(jValue: JValue): Cbor.DataItem =
+  def jValueToCbor(jValue: JValue): Cbor.DataItem =
     jValue match {
       case JInt(num) => firstItem {
         new CborBuilder().add(num.bigInteger)

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -17,7 +17,8 @@ object JValueConversions {
       case JBool(b) => CBool(b)
       case JString(s) => CString(s)
       case JArray(arr) => CArray(arr.map(jValueToCbor))
-      case JObject(fields) => CMap(fields.map(f => (f._1, jValueToCbor(f._2))))
+      case JObject(fields) =>
+        CMap.withStringKeys(fields.map(f => (f._1, jValueToCbor(f._2))))
     }
   }
 }

--- a/transactor/src/main/scala/io/mediachain/util/cbor/package.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/package.scala
@@ -1,0 +1,69 @@
+package io.mediachain.util
+
+import java.io.ByteArrayOutputStream
+
+import co.nstant.in.cbor.CborEncoder
+
+
+package object cbor {
+  import co.nstant.in.cbor.builder.AbstractBuilder
+  import co.nstant.in.cbor.model.{DataItem, SimpleValue, Array => DataItemArray, Map => DataItemMap}
+
+
+  sealed trait CValue
+  case class CNull() extends CValue
+  case class CUndefined() extends CValue
+  case class CInt(num: BigInt) extends CValue
+  case class CLong(num: Long) extends CValue
+  case class CDouble(num: Double) extends CValue
+  case class CBool(bool: Boolean) extends CValue
+  case class CString(string: String) extends CValue
+  case class CBytes(bytes: Array[Byte]) extends CValue
+  case class CArray(items: List[CValue]) extends CValue
+  case class CMap(fields: List[CField]) extends CValue
+  type CField = (String, CValue)
+
+
+
+  def toDataItem(cValue: CValue): DataItem = cValue match {
+    case _: CNull => SimpleValue.NULL
+    case _: CUndefined => SimpleValue.UNDEFINED
+    case CInt(num) => converter.convert(num)
+    case CLong(num) => converter.convert(num)
+    case CDouble(num) => converter.convert(num)
+    case CBool(bool) => converter.convert(bool)
+    case CString(string) => converter.convert(string)
+    case CBytes(bytes) => converter.convert(bytes)
+    case CArray(items) => {
+      val arrayDataItem = new DataItemArray(items.length)
+      items.foreach(item => arrayDataItem.add(toDataItem(item)))
+      arrayDataItem
+    }
+
+    case CMap(fields) => {
+      val mapDataItem = new DataItemMap(fields.length)
+      fields.foreach(field => mapDataItem.put(
+        toDataItem(CString(field._1)), toDataItem(field._2)
+      ))
+      mapDataItem
+    }
+  }
+
+  def encode(cValue: CValue): Array[Byte] = {
+    val out = new ByteArrayOutputStream
+    new CborEncoder(out).encode(toDataItem(cValue))
+    out.close()
+    out.toByteArray
+  }
+
+  private val converter = new DataItemConverter
+  private class DataItemConverter extends AbstractBuilder[Object](null) {
+    def convert(num: BigInt) = super.convert(num.bigInteger)
+    def convert(num: BigDecimal) = super.convert(num.doubleValue)
+    override def convert(num: Long) = super.convert(num)
+    override def convert(num: Double) = super.convert(num)
+    override def convert(boolean: Boolean) = super.convert(boolean)
+    override def convert(string: String) = super.convert(string)
+    override def convert(bytes: Array[Byte]) = super.convert(bytes)
+  }
+}

--- a/transactor/src/test/scala/io/mediachain/BaseSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/BaseSpec.scala
@@ -1,0 +1,8 @@
+package io.mediachain
+
+import org.specs2.Specification
+import org.specs2.matcher.ThrownExpectations
+
+trait BaseSpec extends Specification
+  with XorMatchers
+  with ThrownExpectations

--- a/transactor/src/test/scala/io/mediachain/XorMatchers.scala
+++ b/transactor/src/test/scala/io/mediachain/XorMatchers.scala
@@ -1,0 +1,34 @@
+package io.mediachain
+
+import org.specs2.matcher.Matcher
+import org.specs2.execute.{Failure, Result}
+import org.specs2.matcher.MatchersImplicits._
+import cats.data.Xor
+
+trait XorMatchers {
+  def beRightXor[T](checker: (T => Result)): Matcher[Xor[_, T]] = {
+    (x: Xor[_, T]) => x match {
+      case Xor.Right(value) =>
+        checker(value)
+      case _ =>
+        new Failure(s"Xor value was instance of Xor.Left: $x")
+    }
+  }
+
+  def beRightXor: Matcher[Xor[_, _]] = { (x: Xor[_, _]) =>
+    (x.isRight, s"Xor value was instance of Xor.Left: $x")
+  }
+
+  def beLeftXor[T](checker: (T => Result)): Matcher[Xor[T, _]] = {
+    (x: Xor[T, _]) => x match {
+      case Xor.Left(value) =>
+        checker(value)
+      case _ =>
+        new Failure(s"Xor value was instance of Xor.Right: $x")
+    }
+  }
+
+  def beLeftXor: Matcher[Xor[_, _]] = { (x: Xor[_, _]) =>
+    (x.isLeft, s"Xor value was instance of Xor.Right: $x")
+  }
+}

--- a/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
@@ -1,0 +1,44 @@
+package io.mediachain.transactor
+
+import io.atomix.copycat.client.CopycatClient
+import io.atomix.copycat.server.CopycatServer
+import io.atomix.catalyst.transport.Address
+
+case class DummyContext(
+  server: CopycatServer, 
+  client: CopycatClient, 
+  store: Types.Datastore,
+  logdir: String
+)
+
+object DummyContext {
+  def setup(srvaddr: String, logdir: String) = {
+    println("*** SETUP DUMMY COPYCAT CONTEXT")
+    setupLogdir(logdir)
+    val address = new Address(srvaddr)
+    val store = new Dummies.DummyStore
+    val server = Copycat.Server.build(address, logdir, store)
+    server.bootstrap().join()
+    val client = Copycat.Client.build()
+    client.connect(address).join()
+    DummyContext(server, client, store, logdir)
+  }
+  
+  def setupLogdir(logdir: String) {
+    import sys.process._
+    (s"rm -rf $logdir").!
+    (s"mkdir -p $logdir").!
+  }
+  
+  def cleanupLogdir(logdir: String) {
+    import sys.process._
+    (s"rm -rf $logdir").!
+  }
+  
+  def shutdown(context: DummyContext) {
+    println("*** SHUT DOWN DUMMY COPYCAT CONTEXT")
+    context.client.close().join()
+    context.server.shutdown().join()
+    cleanupLogdir(context.logdir)
+  }
+}

--- a/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
@@ -12,9 +12,9 @@ case class DummyContext(
 )
 
 object DummyContext {
-  def setup(srvaddr: String, logdir: String) = {
+  def setup(srvaddr: String) = {
     println("*** SETUP DUMMY COPYCAT CONTEXT")
-    setupLogdir(logdir)
+    val logdir = setupLogdir()
     val address = new Address(srvaddr)
     val store = new Dummies.DummyStore
     val server = Copycat.Server.build(address, logdir, store)
@@ -24,10 +24,11 @@ object DummyContext {
     DummyContext(server, client, store, logdir)
   }
   
-  def setupLogdir(logdir: String) {
+  def setupLogdir() = {
     import sys.process._
-    (s"rm -rf $logdir").!
+    val logdir = "mktemp -d".!!
     (s"mkdir -p $logdir").!
+    logdir
   }
   
   def cleanupLogdir(logdir: String) {

--- a/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
@@ -7,17 +7,17 @@ import io.atomix.catalyst.transport.Address
 case class DummyContext(
   server: CopycatServer, 
   client: CopycatClient, 
-  store: Types.Datastore,
+  store: Dummies.DummyStore,
   logdir: String
 )
 
 object DummyContext {
-  def setup(srvaddr: String) = {
+  def setup(srvaddr: String, blocksize: Int = StateMachine.JournalBlockSize) = {
     println("*** SETUP DUMMY COPYCAT CONTEXT")
     val logdir = setupLogdir()
     val address = new Address(srvaddr)
     val store = new Dummies.DummyStore
-    val server = Copycat.Server.build(address, logdir, store)
+    val server = Copycat.Server.build(address, logdir, store, blocksize)
     server.bootstrap().join()
     val client = Copycat.Client.build()
     client.connect(address).join()

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec.scala
@@ -1,0 +1,133 @@
+package io.mediachain.transactor
+
+import org.specs2.specification.{AfterAll, BeforeAll}
+
+import java.util.function.Consumer
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+
+import scala.collection.mutable.ListBuffer
+
+import Types._
+import StateMachine._
+
+object JournalBlockchainSpec extends io.mediachain.BaseSpec
+  with BeforeAll
+  with AfterAll
+{
+  def is =
+    sequential ^
+  s2"""
+  JournalStateMachine generates and tracks the blockchain:
+   - it starts with an empty block $hasEmptyBlock
+   - it accumulates journal entries in the current block $accumulateBlock
+   - it generates a block after BlockSize entries $generateBlock
+   - it has an empty block again $hasEmptyBlockAgain
+   - it generates a second block chained to the first $generateAnotherBlock
+  """
+
+  def beforeAll() {
+    JournalBlockchainSpecContext.setup()
+  }
+  
+  def afterAll() {
+    JournalBlockchainSpecContext.shutdown()
+  }
+  
+  def hasEmptyBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val block = context.dummy.client.submit(JournalCurrentBlock()).join()
+    (block.index must_== 0) and
+    (block.chain must beNone) and
+    (block.entries must beEmpty)
+  }
+  
+  def accumulateBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {
+      context.entries += entry
+      context.entityRef = entry.ref
+    })
+    val ref = context.entityRef
+    for (x <- 1 to 5) {
+      val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+      res.foreach((entry: ChainEntry) => {context.entries += entry})
+    }
+    
+    val block = context.dummy.client.submit(JournalCurrentBlock()).join()
+    (block.index must_== 6) and
+    (block.chain must beNone) and
+    (block.entries must_== context.entries.toArray)
+  }
+  
+  def generateBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val ref = context.entityRef
+    for (x <- 6 to (JournalBlockchainSpecContext.BlockSize - 1)) {
+      val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+      res.foreach((entry: ChainEntry) => {context.entries += entry})
+    }
+    context.blockRef = context.queue.poll(1, TimeUnit.SECONDS)
+    val block = context.dummy.store.get(context.blockRef)
+    (block must beSome) and
+    (block.get.asInstanceOf[JournalBlock].index must_== JournalBlockchainSpecContext.BlockSize) and
+    (block.get.asInstanceOf[JournalBlock].chain must beNone) and
+    (block.get.asInstanceOf[JournalBlock].entries must_== context.entries.toArray)
+  }
+  
+  def hasEmptyBlockAgain = {
+    val context = JournalBlockchainSpecContext.context
+    val block = context.dummy.client.submit(JournalCurrentBlock()).join()
+    (block.index must_== JournalBlockchainSpecContext.BlockSize) and
+    (block.chain must_== Some(context.blockRef)) and
+    (block.entries must beEmpty)
+  }
+  
+  def generateAnotherBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val ref = context.entityRef
+    context.entries = new ListBuffer
+    for (x <- 1 to JournalBlockchainSpecContext.BlockSize) {
+      val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+      res.foreach((entry: ChainEntry) => {context.entries += entry})
+    }
+    val blockref = context.queue.poll(1, TimeUnit.SECONDS)
+    val block = context.dummy.store.get(blockref)
+    (block must beSome) and
+    (block.get.asInstanceOf[JournalBlock].index must_== (2 * JournalBlockchainSpecContext.BlockSize)) and
+    (block.get.asInstanceOf[JournalBlock].chain must_== Some(context.blockRef)) and
+    (block.get.asInstanceOf[JournalBlock].entries must_== context.entries.toArray)
+  }
+}
+
+class JournalBlockchainSpecContext(val dummy: DummyContext,
+                                   val queue: BlockingQueue[Reference]) {
+  var entries: ListBuffer[JournalEntry] = new ListBuffer
+  var entityRef: Reference = null
+  var blockRef: Reference = null
+}
+
+object JournalBlockchainSpecContext {
+  val BlockSize = 20
+  var instance: JournalBlockchainSpecContext = null
+  
+  def setup(): Unit = {
+    val dummy = DummyContext.setup("127.0.0.1:10002", BlockSize)
+    val queue = new LinkedBlockingQueue[Reference]
+    dummy.client.onEvent("journal-block", 
+      new Consumer[JournalBlockEvent] { 
+        def accept(evt: JournalBlockEvent) { 
+          queue.offer(evt.ref)
+        }
+    })
+    instance = new JournalBlockchainSpecContext(dummy, queue)
+  }
+  
+  def shutdown(): Unit = {
+    DummyContext.shutdown(instance.dummy)
+  }
+  
+  def context = instance
+}
+
+

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
@@ -1,0 +1,69 @@
+package io.mediachain.transactor
+
+import org.specs2.specification.{AfterAll, BeforeAll}
+
+import java.util.function.Consumer
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+
+import scala.collection.mutable.ListBuffer
+
+import Types._
+import StateMachine._
+
+object JournalBlockchainSpec2 extends io.mediachain.BaseSpec
+  with BeforeAll
+  with AfterAll
+{
+  def is =
+  s2"""
+  JournalStateMachine generates Journal blocks
+   - it generates a full block as quickly as possible $generateBlock
+  """
+  
+  def beforeAll() {
+    JournalBlockchainSpec2Context.setup()
+  }
+  
+  def afterAll() {
+    JournalBlockchainSpec2Context.shutdown()
+  }
+  
+  def generateBlock = {
+    val context = JournalBlockchainSpec2Context.context
+    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {
+      val ref = entry.ref
+      for (x <- 1 to (JournalBlockSize - 1)) {
+        context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map())))
+      }})
+    val blockref = context.queue.poll(300, TimeUnit.SECONDS)
+    val block = context.dummy.store.get(blockref)
+    (block must beSome) and
+    (block.get.asInstanceOf[JournalBlock].index must_== JournalBlockSize)
+  }
+}
+
+class JournalBlockchainSpec2Context(val dummy: DummyContext,
+                                    val queue: BlockingQueue[Reference])
+
+object JournalBlockchainSpec2Context {
+  var instance: JournalBlockchainSpec2Context = null
+
+  def setup(): Unit = {
+    val dummy = DummyContext.setup("127.0.0.1:10003")
+    val queue = new LinkedBlockingQueue[Reference]
+    dummy.client.onEvent("journal-block", 
+      new Consumer[JournalBlockEvent] { 
+        def accept(evt: JournalBlockEvent) { 
+          queue.offer(evt.ref)
+        }
+    })
+    instance = new JournalBlockchainSpec2Context(dummy, queue)
+  }
+  
+  def shutdown(): Unit = {
+    DummyContext.shutdown(instance.dummy)
+  }
+  
+  def context = instance
+}

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalCommitSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalCommitSpec.scala
@@ -1,0 +1,117 @@
+package io.mediachain.transactor
+
+import org.specs2.specification.{AfterAll, BeforeAll}
+
+import java.util.function.Consumer
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+
+import io.atomix.copycat.client.CopycatClient
+import io.atomix.catalyst.transport.Address
+
+import Types._
+import StateMachine._
+
+object JournalCommitSpec extends io.mediachain.BaseSpec
+  with BeforeAll
+  with AfterAll
+{
+
+  def is =
+    sequential ^
+  s2"""
+  JournalStateMachine publishes commit events:
+   - when inserting an entity $insertEntity
+   - when extending the entity chain $extendEntityChain
+   - when extending the entity chain further $extendEntityChainFurther
+   - when inserting an artefact $insertArtefact
+   - when extending the artefact chain $extendArtefactChain
+  """
+
+  def beforeAll() {
+    JournalCommitSpecContext.setup()
+  }
+  
+  def afterAll() {
+    JournalCommitSpecContext.shutdown()
+  }
+  
+  def insertEntity = {
+    val context = JournalCommitSpecContext.context
+    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {context.ref = entry.ref})
+    val entry = context.queue.poll(1, TimeUnit.SECONDS)
+    res must beRightXor { (xentry: CanonicalEntry) =>
+      entry must_== xentry
+    }
+  }
+  
+  def extendEntityChain = {
+    val context = JournalCommitSpecContext.context
+    val ref = context.ref
+    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    val entry = context.queue.poll(1, TimeUnit.SECONDS)
+    res must beRightXor { (xentry: ChainEntry) =>
+      entry must_== xentry
+    }
+  }
+  
+  def extendEntityChainFurther = {
+    val context = JournalCommitSpecContext.context
+    val ref = context.ref
+    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    val entry = context.queue.poll(1, TimeUnit.SECONDS)
+    res must beRightXor { (xentry: ChainEntry) =>
+      entry must_== xentry
+    }
+  }
+  
+  def insertArtefact = {
+    val context = JournalCommitSpecContext.context
+    val res = context.dummy.client.submit(JournalInsert(Artefact(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {context.ref = entry.ref})
+    val entry = context.queue.poll(1, TimeUnit.SECONDS)
+    res must beRightXor { (xentry: CanonicalEntry) =>
+      entry must_== xentry
+    }
+  }
+  
+  def extendArtefactChain = {
+    val context = JournalCommitSpecContext.context
+    val ref = context.ref
+    val res = context.dummy.client.submit(JournalUpdate(ref, ArtefactChainCell(ref, None, Map()))).join()
+    val entry = context.queue.poll(1, TimeUnit.SECONDS)
+    res must beRightXor { (xentry: ChainEntry) =>
+      entry must_== xentry
+    }
+  }
+}
+
+class JournalCommitSpecContext(val dummy: DummyContext, 
+                               val qclient: CopycatClient, 
+                               val queue: BlockingQueue[JournalEntry]) {
+  var ref: Reference = null
+}
+
+object JournalCommitSpecContext {
+  var instance: JournalCommitSpecContext = null
+  def setup() {
+    val dummy = DummyContext.setup("127.0.0.1:10001", "/tmp/transactor-test/commit")
+    val qclient = Copycat.Client.build()
+    val queue = new LinkedBlockingQueue[JournalEntry]
+    qclient.connect(new Address("127.0.0.1:10001")).join()
+    qclient.onEvent("journal-commit", 
+      new Consumer[JournalCommitEvent] { 
+        def accept(evt: JournalCommitEvent) { 
+          queue.offer(evt.entry)
+        }
+    })
+    instance = new JournalCommitSpecContext(dummy, qclient, queue)
+  }
+  
+  def shutdown() {
+    instance.qclient.close().join()
+    DummyContext.shutdown(instance.dummy)
+  }
+  
+  def context = instance
+}

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalCommitSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalCommitSpec.scala
@@ -94,8 +94,8 @@ class JournalCommitSpecContext(val dummy: DummyContext,
 
 object JournalCommitSpecContext {
   var instance: JournalCommitSpecContext = null
-  def setup() {
-    val dummy = DummyContext.setup("127.0.0.1:10001", "/tmp/transactor-test/commit")
+  def setup(): Unit = {
+    val dummy = DummyContext.setup("127.0.0.1:10001")
     val qclient = Copycat.Client.build()
     val queue = new LinkedBlockingQueue[JournalEntry]
     qclient.connect(new Address("127.0.0.1:10001")).join()
@@ -108,7 +108,7 @@ object JournalCommitSpecContext {
     instance = new JournalCommitSpecContext(dummy, qclient, queue)
   }
   
-  def shutdown() {
+  def shutdown(): Unit = {
     instance.qclient.close().join()
     DummyContext.shutdown(instance.dummy)
   }

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalIndexSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalIndexSpec.scala
@@ -1,0 +1,168 @@
+package io.mediachain.transactor
+
+import org.specs2.specification.{AfterAll, BeforeAll}
+
+import Types._
+import StateMachine._
+
+object JournalIndexSpec extends io.mediachain.BaseSpec
+  with BeforeAll
+  with AfterAll
+{
+  
+  def is =
+    sequential ^
+  s2"""
+  JournalStateMachine maintains a consistent Journal Index:
+   - inserts entity $insertEntity
+   - resolves entity to empty chain $resolveEntityEmpty
+   - extends entity chain $extendEntityChain
+   - resolves entity chain $resolveEntityChain
+   - extends entity chain further $extendEntityChainFurther
+   - inserts artefact $insertArtefact
+   - resolves artefact to empty chain $resolveArtefactEmpty
+   - extends artefact chain $extendArtefactChain
+   - resolves artefact chain $resolveArtefactChain
+   - extends artefact chain further $extendArtefactChainFurther
+   - does not allow ArtefactCells on Entity chain $checkEntityXCons
+   - does not allow EntityChainCells on Artefact chain $checkArtefactXCons
+  """
+  
+  def beforeAll() {
+    JournalIndexSpecContext.setup()
+  }
+  
+  def afterAll() {
+    JournalIndexSpecContext.shutdown()
+  }
+
+  def insertEntity = {
+    val context = JournalIndexSpecContext.context
+    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {context.entityRef = entry.ref})
+    res must beRightXor
+  }
+  
+  def resolveEntityEmpty = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.entityRef
+    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    res must beNone
+  }
+  
+  def extendEntityChain = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.entityRef
+    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    res.foreach((entry: ChainEntry) => {context.entityChainRef = entry.chain})
+    res must beRightXor { (entry: ChainEntry) =>
+      (entry.ref must_== ref) and 
+      (entry.chainPrevious must beNone)
+    }
+  }
+  
+  def resolveEntityChain = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.entityRef
+    val chainRef = context.entityChainRef
+    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    (res must beSome) and 
+    (res.get must_== chainRef)
+  }
+  
+  def extendEntityChainFurther = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.entityRef
+    val chainRef = context.entityChainRef
+    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    res.foreach((entry: ChainEntry) => {context.entityChainRef = entry.chain})
+    res must beRightXor { (entry: ChainEntry) =>
+      (entry.ref must_== ref) and 
+      (entry.chainPrevious must beSome) and
+      (entry.chainPrevious.get must_== chainRef)
+    }
+  }
+  
+  def insertArtefact = {
+    val context = JournalIndexSpecContext.context
+    val res = context.dummy.client.submit(JournalInsert(Artefact(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {context.artefactRef = entry.ref})
+    res must beRightXor
+  }
+
+  def resolveArtefactEmpty = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.artefactRef
+    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    res must beNone
+  }
+  
+  def extendArtefactChain = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.artefactRef
+    val res = context.dummy.client.submit(JournalUpdate(ref, ArtefactChainCell(ref, None, Map()))).join()
+    res.foreach((entry: ChainEntry) => {context.artefactChainRef = entry.chain})
+    res must beRightXor { (entry: ChainEntry) =>
+      (entry.ref must_== ref) and 
+      (entry.chainPrevious must beNone)
+    }
+  }
+  
+  def resolveArtefactChain = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.artefactRef
+    val chainRef = context.artefactChainRef
+    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    (res must beSome) and 
+    (res.get must_== chainRef)
+  }
+
+  def extendArtefactChainFurther = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.artefactRef
+    val chainRef = context.artefactChainRef
+    val res = context.dummy.client.submit(JournalUpdate(ref, ArtefactChainCell(ref, None, Map()))).join()
+    res.foreach((entry: ChainEntry) => {context.artefactChainRef = entry.chain})
+    res must beRightXor { (entry: ChainEntry) =>
+      (entry.ref must_== ref) and 
+      (entry.chainPrevious must beSome) and
+      (entry.chainPrevious.get must_== chainRef)
+    }
+  }
+  
+  def checkEntityXCons = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.entityRef
+    val res = context.dummy.client.submit(JournalUpdate(ref, ArtefactChainCell(ref, None, Map()))).join()
+    res must beLeftXor
+  }
+  
+  def checkArtefactXCons = {
+    val context = JournalIndexSpecContext.context
+    val ref = context.artefactRef
+    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    res must beLeftXor
+  }
+}
+
+class JournalIndexSpecContext(val dummy: DummyContext) {
+  var entityRef: Reference = null
+  var entityChainRef: Reference = null
+  var artefactRef: Reference = null
+  var artefactChainRef: Reference = null
+}
+
+object JournalIndexSpecContext {
+  var instance: JournalIndexSpecContext = null
+  
+  def setup() {
+    val dummy = DummyContext.setup("127.0.0.1:10000", "/tmp/transactor-test/index")
+    instance = new JournalIndexSpecContext(dummy)
+  }
+  
+  def shutdown() {
+    DummyContext.shutdown(instance.dummy)
+  }
+  
+  def context = instance
+}

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalIndexSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalIndexSpec.scala
@@ -155,12 +155,12 @@ class JournalIndexSpecContext(val dummy: DummyContext) {
 object JournalIndexSpecContext {
   var instance: JournalIndexSpecContext = null
   
-  def setup() {
-    val dummy = DummyContext.setup("127.0.0.1:10000", "/tmp/transactor-test/index")
+  def setup(): Unit = {
+    val dummy = DummyContext.setup("127.0.0.1:10000")
     instance = new JournalIndexSpecContext(dummy)
   }
   
-  def shutdown() {
+  def shutdown(): Unit = {
     DummyContext.shutdown(instance.dummy)
   }
   

--- a/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
+++ b/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
@@ -1,0 +1,60 @@
+package io.mediachain.util.cbor
+
+import org.scalacheck._
+import Arbitrary.arbitrary
+import io.mediachain.util.cbor.CborAST._
+import co.nstant.in.cbor.model.{DataItem, RationalNumber, UnsignedInteger, LanguageTaggedString}
+
+object CValueGenerators {
+
+
+  val genCNull = Gen.const(CNull())
+  val genCUndefined = Gen.const(CUndefined())
+  val genCInt = for (i <- arbitrary[BigInt]) yield CInt(i)
+  val genCDouble = for (d <- arbitrary[Double]) yield CDouble(d)
+  val genCBool = for (b <- arbitrary[Boolean]) yield CBool(b)
+  val genCString = for(s <- arbitrary[String]) yield CString(s)
+  val genCBytes = for (b <- arbitrary[Array[Byte]]) yield CBytes(b)
+
+
+  val genCPrimitive = Gen.oneOf(
+    genCNull, genCUndefined, genCInt, genCDouble, genCBool, genCBytes, genCString
+  )
+
+  val genCArray = for {
+    list <- Gen.containerOf[List, CValue](genCPrimitive)
+  } yield CArray(list)
+
+
+  val genCMap = for {
+    keys <- Gen.containerOf[List, CValue](Gen.oneOf(genCInt, genCDouble, genCString))
+    vals <- Gen.containerOfN[List, CValue](keys.length, genCPrimitive)
+    kvs = (keys, vals).zipped.toList
+  } yield CMap(kvs)
+
+
+  // Generate some DataItems we don't unwrap for CUnhandled generator
+  val genRational = for {
+    numerator <- Gen.posNum[Long]
+    denominator <- Gen.posNum[Long]
+  } yield new RationalNumber(
+    new UnsignedInteger(numerator),
+    new UnsignedInteger(denominator)
+  )
+
+  val genTaggedString = for {
+    lang <- Gen.oneOf("en", "fr", "es")
+    str <- Gen.alphaStr
+  } yield new LanguageTaggedString(lang, str)
+
+  val genCUnhandled = for {
+    dataItem <- Gen.oneOf[DataItem](genRational, genTaggedString)
+  } yield CUnhandled(dataItem)
+
+  val genCValue = Gen.oneOf(
+    genCPrimitive, genCArray, genCMap,
+    genCUnhandled
+  )
+
+  implicit def arbitraryCValue: Arbitrary[CValue] = Arbitrary(genCValue)
+}

--- a/transactor/src/test/scala/io/mediachain/util/cbor/CborASTSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/util/cbor/CborASTSpec.scala
@@ -1,0 +1,34 @@
+package io.mediachain.util.cbor
+
+import java.io.ByteArrayOutputStream
+
+import io.mediachain.BaseSpec
+import io.mediachain.util.cbor.CborAST._
+import org.specs2.ScalaCheck
+
+object CborASTSpec extends BaseSpec with ScalaCheck {
+  import io.mediachain.util.cbor.CValueGenerators._
+  import co.nstant.in.cbor.CborEncoder
+
+  def is =
+    s2"""
+         - round-trip encodes to/from cbor-java DataItems $roundTripCborJava
+      """
+
+  def roundTripCborJava = prop { cVal: CValue =>
+    val asDataItem = toDataItem(cVal)
+    val converted = toDataItem(fromDataItem(asDataItem))
+
+
+    // We're comparing the DataItem representation because it will not
+    // fail if the ordering of map keys differs, whereas CMaps will not
+    // be equal if the ordering is different
+    asDataItem must_== converted
+
+    // make sure byte representation is equal
+    val out = new ByteArrayOutputStream
+    new CborEncoder(out).encode(asDataItem)
+    out.close()
+    out.toByteArray must_== CborCodec.encode(cVal)
+  }
+}


### PR DESCRIPTION
This is an alternative to #35 that doesn't use the jackson CBOR module.  Instead it uses [cbor-java](https://github.com/c-rack/cbor-java) and provides a `jValueToCbor` method to convert from JValue.  

Doesn't handle the other direction (cbor to json), since that's a lossy conversion.
