### PR TITLE
Remove unneccessary setup method and var

### DIFF
--- a/transactor/src/test/scala/io/mediachain/transactor/JournalCommitSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalCommitSpec.scala
@@ -28,7 +28,6 @@ object JournalCommitSpec extends io.mediachain.BaseSpec
   """
 
   def beforeAll() {
-    JournalCommitSpecContext.setup()
   }
   
   def afterAll() {
@@ -93,25 +92,21 @@ class JournalCommitSpecContext(val dummy: DummyContext,
 }
 
 object JournalCommitSpecContext {
-  var instance: JournalCommitSpecContext = null
-  def setup(): Unit = {
-    val dummy = DummyContext.setup("127.0.0.1:10001")
-    val qclient = Copycat.Client.build()
-    val queue = new LinkedBlockingQueue[JournalEntry]
-    qclient.connect(new Address("127.0.0.1:10001")).join()
-    qclient.onEvent("journal-commit", 
-      new Consumer[JournalCommitEvent] { 
-        def accept(evt: JournalCommitEvent) { 
-          queue.offer(evt.entry)
-        }
-    })
-    instance = new JournalCommitSpecContext(dummy, qclient, queue)
-  }
+  val dummy = DummyContext.setup("127.0.0.1:10001")
+  val qclient = Copycat.Client.build()
+  val queue = new LinkedBlockingQueue[JournalEntry]
+  qclient.connect(new Address("127.0.0.1:10001")).join()
+  qclient.onEvent("journal-commit",
+    new Consumer[JournalCommitEvent] {
+      def accept(evt: JournalCommitEvent) {
+        queue.offer(evt.entry)
+      }
+  })
+  val context = new JournalCommitSpecContext(dummy, qclient, queue)
+
   
   def shutdown(): Unit = {
-    instance.qclient.close().join()
-    DummyContext.shutdown(instance.dummy)
+    context.qclient.close().join()
+    DummyContext.shutdown(context.dummy)
   }
-  
-  def context = instance
 }


### PR DESCRIPTION
I'm seeing many examples of this pattern where we start with a null var and then call an initializer method. This is really not necessary unless we want very precise control over when the init is called.

Scala objects (singletons) are already lazy, and have inline constructors:

``` scala
scala> object SoLazy {
     | println("executing body!")
     | val foo = { println("executing val!"); 99 }
     | def bar = { println("executing def!"); 22 }
     | def fire = 101
     | }
defined object SoLazy

scala> SoLazy.fire
executing body!
executing val!
res2: Int = 101
```

I might be missing something about your intention, but from my perspective this achieves the same effect. 

(this is not a complete set of changes but I wanted to isolate them to be illustrative)
