### PR TITLE
very simple sample datastore json example

### DIFF
--- a/sample-data/picasso.json
+++ b/sample-data/picasso.json
@@ -1,0 +1,50 @@
+{
+  "Qm000": { "type": "nil" },
+
+  "Qm001": {
+    "type": "entity",
+    "name": "Pablo Picasso",
+
+    "@context": "http://schema.org/Person",
+    "birthDate": "1881-10-25"
+  },
+
+  "Qm002": {
+    "type": "artefact",
+    "name": "The Starry Night",
+
+    "@context": "http://schema.org/Painting",
+    "dateCreated": "1889"
+  },
+
+  "Qm003": {
+    "type": "artefactCreatedBy",
+    "artefact": {"@link": "Qm002"},
+    "entity": {"@link": "Qm001"},
+    "chain": {"@link": "Qm000"}
+  },
+
+  "Qm004": {
+    "type": "artefact",
+    "name": "Cypresses in Starry Night",
+
+    "@context": "http://schema.org/VisualArtwork",
+    "artform": "Drawing",
+    "artMedium": "Ink, Reed Pen",
+    "dateCreated": "1889"
+  },
+
+  "Qm005": {
+    "type": "artefactCreatedBy",
+    "artefact": {"@link": "Qm004"},
+    "entity": {"@link": "Qm001"},
+    "chain": {"@link": "Qm000"}
+  },
+
+  "Qm006": {
+    "type": "artefactDerivedBy",
+    "artefact": "Qm004",
+    "artefactOrigin": "Qm002",
+    "chain": "Qm005"
+  }
+}


### PR DESCRIPTION
Don't merge me bro!  This is just here to get some eyes on it and make sure I'm basically barking up the right tree, data format wise.

The `picasso.json` file is a simple dummy "datastore", where the refs are just made up strings in a big object e.g. `"Qm001"`.  It has one `Entity` (picasso), and two works, one of which is a derivative of the other; the pen sketch of the starry night is derived from the painting.  Everything is missing signatures, so you can use your imagination there :)

The schema.org stuff is just there so I had some fields to work with for things like `artform`, etc...  I'm not saying we should use that as our data model.  Although... it may actually work alright, given that it was created for search engines, and indexing is our main motivation for extracting / translating raw metadata.  And we do need to decide on some kind of field to indicate what kind of artefact / entity we're talking about.  
