### PR TITLE
Transactor StateMachine: Journal blockchain generation

### DIFF
--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -13,11 +13,12 @@ object Copycat {
   import io.mediachain.transactor.Types.Datastore
 
   object Server {
-    def build(address: Address, logdir: String, datastore: Datastore): CopycatServer = {
+    def build(address: Address, logdir: String, datastore: Datastore,
+              blocksize: Int = StateMachine.JournalBlockSize): CopycatServer = {
       def stateMachineSupplier() = {
         new Supplier[CopycatStateMachine] {
           override def get: CopycatStateMachine = {
-            new JournalStateMachine(datastore)
+            new JournalStateMachine(datastore, blocksize)
           }
         }
       }

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -16,12 +16,12 @@ object Dummies {
   
   class DummyStore extends Datastore {
     var seqno = 0
-    val records: MMap[Reference, Record] = new MHashMap
+    val store: MMap[Reference, DataObject] = new MHashMap
     
-    override def put(rec: Record): Reference = {
+    override def put(obj: DataObject): Reference = {
       val ref = new DummyReference(seqno)
       seqno += 1
-      records += (ref -> rec)
+      store += (ref -> obj)
       ref
     }
   }

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -24,6 +24,8 @@ object Dummies {
       store += (ref -> obj)
       ref
     }
+    
+    def get(ref: Reference) = store.get(ref)
   }
 
 }

--- a/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
@@ -1,7 +1,8 @@
 package io.mediachain.transactor
 
 import scala.collection.mutable.{Set => MSet, HashSet => MHashSet, 
-                                 Map => MMap, HashMap => MHashMap}
+                                 Map => MMap, HashMap => MHashMap,
+                                 ListBuffer}
 
 import io.atomix.copycat.{Command, Query}
 import io.atomix.copycat.server.{Commit, StateMachine => CopycatStateMachine, Snapshottable}
@@ -25,15 +26,23 @@ object StateMachine {
   case class JournalLookup(
     ref: Reference
   ) extends Query[Option[Reference]]
+
+  case class JournalCurrentBlock() extends Query[JournalBlock]
   
-  case class JournalCommitEvent(entry: JournalEntry) extends Serializable
+  sealed abstract class JournalEvent extends Serializable
+  case class JournalCommitEvent(entry: JournalEntry) extends JournalEvent
+  case class JournalBlockEvent(ref: Reference) extends JournalEvent
 
   class JournalStateMachine(
-    val datastore: Datastore
+    val datastore: Datastore,
+    val blocksize: Int = 4096
   ) extends CopycatStateMachine with Snapshottable with SessionListener {
     private var seqno: BigInt = 0
     private var index: MMap[Reference, ChainReference] = new MHashMap // canonical -> chain map
-    private val clients: MSet[ServerSession] = new MHashSet // this wanted to be called sessions
+    private var block: ListBuffer[JournalEntry] = new ListBuffer      // current block entries
+    private var blockchain: Option[Reference] = None                  // blockchain head
+    private val clients: MSet[ServerSession] = new MHashSet           // this wanted to be called sessions
+
 
     private def commitError(what: String) = Xor.left(JournalCommitError(what))
     
@@ -56,6 +65,7 @@ object StateMachine {
 
           val entry = CanonicalEntry(nextSeqno(), ref)
           publishCommit(entry)
+          blockExtend(entry)
           Xor.right(entry)
         }
       }
@@ -73,6 +83,7 @@ object StateMachine {
       def commit(ref: Reference, newchain: Reference, oldchain: Option[Reference]) = {
         val entry = ChainEntry(nextSeqno(), ref, newchain, oldchain)
         publishCommit(entry)
+        blockExtend(entry)
         Xor.right(entry)
       }
       
@@ -111,6 +122,27 @@ object StateMachine {
         commit.release()
       }
     }
+    
+    def currentBlock(commit: Commit[JournalCurrentBlock]) : JournalBlock = {
+      try {
+        JournalBlock(seqno, blockchain, block.toList)
+      } finally {
+        commit.release()
+      }
+    }
+
+    // block generation
+    private def blockExtend(entry: JournalEntry) {
+      block += entry
+      if (block.length >= blocksize) {
+        val entries = block.toList
+        val newblock = JournalBlock(seqno, blockchain, entries)
+        val blockref = datastore.put(newblock)
+        blockchain = Some(blockref)
+        block = new ListBuffer
+        publishBlock(blockref)
+      }
+    }
 
     // helpers
     private def nextSeqno() = {
@@ -119,12 +151,15 @@ object StateMachine {
       next
     }
     
-
     private def publishCommit(entry: JournalEntry) {
       val event = JournalCommitEvent(entry)
       clients.foreach(_.publish("journal-commit", event))
     }
     
+    private def publishBlock(blockref: Reference) {
+      val event = JournalBlockEvent(blockref)
+      clients.foreach(_.publish("journal-block", event))
+    }
     
     private def checkUpdate(ref: Reference, chain: Option[Reference],
                             xref: Reference, xchain: Option[Reference]) = {
@@ -135,11 +170,15 @@ object StateMachine {
     override def install(reader: SnapshotReader) {
       seqno = reader.readObject()
       index = reader.readObject()
+      block = reader.readObject()
+      blockchain = reader.readObject()
     }
     
     override def snapshot(writer: SnapshotWriter) {
       writer.writeObject(seqno)
       writer.writeObject(index)
+      writer.writeObject(block)
+      writer.writeObject(blockchain)
     }
     
     // Session Listener

--- a/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
@@ -126,7 +126,7 @@ object StateMachine {
     
     def currentBlock(commit: Commit[JournalCurrentBlock]) : JournalBlock = {
       try {
-        JournalBlock(seqno, blockchain, block.toList)
+        JournalBlock(seqno, blockchain, block.toArray)
       } finally {
         commit.release()
       }
@@ -136,7 +136,7 @@ object StateMachine {
     private def blockExtend(entry: JournalEntry) {
       block += entry
       if (block.length >= JournalBlockSize) {
-        val entries = block.toList
+        val entries = block.toArray
         val newblock = JournalBlock(seqno, blockchain, entries)
         val blockref = datastore.put(newblock)
         blockchain = Some(blockref)

--- a/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
@@ -36,7 +36,8 @@ object StateMachine {
   case class JournalBlockEvent(ref: Reference) extends JournalEvent
 
   class JournalStateMachine(
-    val datastore: Datastore
+    val datastore: Datastore,
+    val blocksize: Int = JournalBlockSize // configurable to facilitate testing
   ) extends CopycatStateMachine with Snapshottable with SessionListener {
     private var seqno: BigInt = 0
     private var index: MMap[Reference, ChainReference] = new MHashMap // canonical -> chain map
@@ -135,7 +136,7 @@ object StateMachine {
     // block generation
     private def blockExtend(entry: JournalEntry) {
       block += entry
-      if (block.length >= JournalBlockSize) {
+      if (block.length >= blocksize) {
         val entries = block.toArray
         val newblock = JournalBlock(seqno, blockchain, entries)
         val blockref = datastore.put(newblock)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -90,7 +90,7 @@ object Types {
   case class JournalBlock(
     index: BigInt,
     chain: Option[Reference],
-    entries: Seq[JournalEntry]
+    entries: Array[JournalEntry]
   ) extends DataObject
   
   // Journal transactor interface

--- a/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
@@ -7,17 +7,17 @@ import io.atomix.catalyst.transport.Address
 case class DummyContext(
   server: CopycatServer, 
   client: CopycatClient, 
-  store: Types.Datastore,
+  store: Dummies.DummyStore,
   logdir: String
 )
 
 object DummyContext {
-  def setup(srvaddr: String) = {
+  def setup(srvaddr: String, blocksize: Int = StateMachine.JournalBlockSize) = {
     println("*** SETUP DUMMY COPYCAT CONTEXT")
     val logdir = setupLogdir()
     val address = new Address(srvaddr)
     val store = new Dummies.DummyStore
-    val server = Copycat.Server.build(address, logdir, store)
+    val server = Copycat.Server.build(address, logdir, store, blocksize)
     server.bootstrap().join()
     val client = Copycat.Client.build()
     client.connect(address).join()

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec.scala
@@ -1,0 +1,133 @@
+package io.mediachain.transactor
+
+import org.specs2.specification.{AfterAll, BeforeAll}
+
+import java.util.function.Consumer
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+
+import scala.collection.mutable.ListBuffer
+
+import Types._
+import StateMachine._
+
+object JournalBlockchainSpec extends io.mediachain.BaseSpec
+  with BeforeAll
+  with AfterAll
+{
+  def is =
+    sequential ^
+  s2"""
+  JournalStateMachine generates and tracks the blockchain:
+   - it starts with an empty block $hasEmptyBlock
+   - it accumulates journal entries in the current block $accumulateBlock
+   - it generates a block after BlockSize entries $generateBlock
+   - it has an empty block again $hasEmptyBlockAgain
+   - it generates a second block chained to the first $generateAnotherBlock
+  """
+
+  def beforeAll() {
+    JournalBlockchainSpecContext.setup()
+  }
+  
+  def afterAll() {
+    JournalBlockchainSpecContext.shutdown()
+  }
+  
+  def hasEmptyBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val block = context.dummy.client.submit(JournalCurrentBlock()).join()
+    (block.index must_== 0) and
+    (block.chain must beNone) and
+    (block.entries must beEmpty)
+  }
+  
+  def accumulateBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {
+      context.entries += entry
+      context.entityRef = entry.ref
+    })
+    val ref = context.entityRef
+    for (x <- 1 to 5) {
+      val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+      res.foreach((entry: ChainEntry) => {context.entries += entry})
+    }
+    
+    val block = context.dummy.client.submit(JournalCurrentBlock()).join()
+    (block.index must_== 6) and
+    (block.chain must beNone) and
+    (block.entries must_== context.entries.toArray)
+  }
+  
+  def generateBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val ref = context.entityRef
+    for (x <- 6 to (JournalBlockchainSpecContext.BlockSize - 1)) {
+      val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+      res.foreach((entry: ChainEntry) => {context.entries += entry})
+    }
+    context.blockRef = context.queue.poll(1, TimeUnit.SECONDS)
+    val block = context.dummy.store.get(context.blockRef)
+    (block must beSome) and
+    (block.get.asInstanceOf[JournalBlock].index must_== JournalBlockchainSpecContext.BlockSize) and
+    (block.get.asInstanceOf[JournalBlock].chain must beNone) and
+    (block.get.asInstanceOf[JournalBlock].entries must_== context.entries.toArray)
+  }
+  
+  def hasEmptyBlockAgain = {
+    val context = JournalBlockchainSpecContext.context
+    val block = context.dummy.client.submit(JournalCurrentBlock()).join()
+    (block.index must_== JournalBlockchainSpecContext.BlockSize) and
+    (block.chain must_== Some(context.blockRef)) and
+    (block.entries must beEmpty)
+  }
+  
+  def generateAnotherBlock = {
+    val context = JournalBlockchainSpecContext.context
+    val ref = context.entityRef
+    context.entries = new ListBuffer
+    for (x <- 1 to JournalBlockchainSpecContext.BlockSize) {
+      val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+      res.foreach((entry: ChainEntry) => {context.entries += entry})
+    }
+    val blockref = context.queue.poll(1, TimeUnit.SECONDS)
+    val block = context.dummy.store.get(blockref)
+    (block must beSome) and
+    (block.get.asInstanceOf[JournalBlock].index must_== (2 * JournalBlockchainSpecContext.BlockSize)) and
+    (block.get.asInstanceOf[JournalBlock].chain must_== Some(context.blockRef)) and
+    (block.get.asInstanceOf[JournalBlock].entries must_== context.entries.toArray)
+  }
+}
+
+class JournalBlockchainSpecContext(val dummy: DummyContext,
+                                   val queue: BlockingQueue[Reference]) {
+  var entries: ListBuffer[JournalEntry] = new ListBuffer
+  var entityRef: Reference = null
+  var blockRef: Reference = null
+}
+
+object JournalBlockchainSpecContext {
+  val BlockSize = 20
+  var instance: JournalBlockchainSpecContext = null
+  
+  def setup(): Unit = {
+    val dummy = DummyContext.setup("127.0.0.1:10002", BlockSize)
+    val queue = new LinkedBlockingQueue[Reference]
+    dummy.client.onEvent("journal-block", 
+      new Consumer[JournalBlockEvent] { 
+        def accept(evt: JournalBlockEvent) { 
+          queue.offer(evt.ref)
+        }
+    })
+    instance = new JournalBlockchainSpecContext(dummy, queue)
+  }
+  
+  def shutdown(): Unit = {
+    DummyContext.shutdown(instance.dummy)
+  }
+  
+  def context = instance
+}
+
+

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
@@ -1,0 +1,69 @@
+package io.mediachain.transactor
+
+import org.specs2.specification.{AfterAll, BeforeAll}
+
+import java.util.function.Consumer
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+
+import scala.collection.mutable.ListBuffer
+
+import Types._
+import StateMachine._
+
+object JournalBlockchainSpec2 extends io.mediachain.BaseSpec
+  with BeforeAll
+  with AfterAll
+{
+  def is =
+  s2"""
+  JournalStateMachine generates Journal blocks
+   - it generates a full block as quickly as possible $generateBlock
+  """
+  
+  def beforeAll() {
+    JournalBlockchainSpec2Context.setup()
+  }
+  
+  def afterAll() {
+    JournalBlockchainSpec2Context.shutdown()
+  }
+  
+  def generateBlock = {
+    val context = JournalBlockchainSpec2Context.context
+    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    res.foreach((entry: CanonicalEntry) => {
+      val ref = entry.ref
+      for (x <- 1 to (JournalBlockSize - 1)) {
+        context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map())))
+      }})
+    val blockref = context.queue.poll(300, TimeUnit.SECONDS)
+    val block = context.dummy.store.get(blockref)
+    (block must beSome) and
+    (block.get.asInstanceOf[JournalBlock].index must_== JournalBlockSize)
+  }
+}
+
+class JournalBlockchainSpec2Context(val dummy: DummyContext,
+                                    val queue: BlockingQueue[Reference])
+
+object JournalBlockchainSpec2Context {
+  var instance: JournalBlockchainSpec2Context = null
+
+  def setup(): Unit = {
+    val dummy = DummyContext.setup("127.0.0.1:10003")
+    val queue = new LinkedBlockingQueue[Reference]
+    dummy.client.onEvent("journal-block", 
+      new Consumer[JournalBlockEvent] { 
+        def accept(evt: JournalBlockEvent) { 
+          queue.offer(evt.ref)
+        }
+    })
+    instance = new JournalBlockchainSpec2Context(dummy, queue)
+  }
+  
+  def shutdown(): Unit = {
+    DummyContext.shutdown(instance.dummy)
+  }
+  
+  def context = instance
+}


### PR DESCRIPTION
#22
- Adds type support for JournalBlocks
- extends the StateMachine to query and generate the journal blockchain every X journal entries

More specifically, the StateMachine API is extended as follows:
- there is a JournalCurrentBlock query that provides access to the current working block
- Every JournalBlockSize entries a new block is generated, stored in the datastore and a reference to the blob is published to clients with a "journal-block" event.

Note that I elected to deterministically generate a block every blocksize entries in order to avoid the pitfalls and complexities of using timers with copycat (it isn't pretty).
The Journal allows the current block to be queried, which is sufficient for a joining client to bootstrap.
