### PR TITLE
add junit xml to circle ci test output

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,8 @@ dependencies:
     - echo "java $SBT_OPTS -jar \`dirname \$0\`/sbt-launch.jar \"\$@\"" > $HOME/bin/sbt
     - chmod u+x $HOME/bin/sbt
     - which sbt
+test:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+  override:
+    - sbt -Dspecs2.junit.outdir=$CIRCLE_TEST_REPORTS/junit "test-only -- junitxml console"


### PR DESCRIPTION
This gives us a bit more detail when circle runs our tests.  Most notably, we get timing information for each specs2 example.
