### PR TITLE
Transactor: Journal client interface

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,8 @@ object MediachainBuild extends Build {
       "org.specs2" %% "specs2-core" % "3.7" % "test",
       "org.specs2" %% "specs2-junit" % "3.7" % "test",
       "org.specs2" %% "specs2-matcher-extra" % "3.7" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.13.0" % "test"
+      "org.scalacheck" %% "scalacheck" % "1.13.0" % "test",
+      "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0-RC1"
     ),
     scalacOptions in Test ++= Seq("-Yrangepos")
   )

--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -15,7 +15,7 @@ object Copycat {
   import io.mediachain.transactor.Types._
 
   object Server {
-    def build(address: Address, logdir: String, datastore: Datastore,
+    def build(address: String, logdir: String, datastore: Datastore,
               blocksize: Int = StateMachine.JournalBlockSize): CopycatServer = {
       def stateMachineSupplier() = {
         new Supplier[CopycatStateMachine] {
@@ -25,7 +25,7 @@ object Copycat {
         }
       }
       
-      val server = CopycatServer.builder(address)
+      val server = CopycatServer.builder(new Address(address))
                     .withStateMachine(stateMachineSupplier())
                     .withStorage(Storage.builder()
                                   .withDirectory(new File(logdir))

--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -44,16 +44,16 @@ object Copycat {
     private var listeners: Set[JournalListener] = Set()
     
     // Journal 
-    def insert(rec: CanonicalRecord) =
+    def insert(rec: CanonicalRecord): Future[Xor[JournalError, CanonicalEntry]] =
       FutureConverters.toScala(client.submit(JournalInsert(rec)))
 
-    def update(ref: Reference, cell: ChainCell) =
+    def update(ref: Reference, cell: ChainCell): Future[Xor[JournalError, ChainEntry]] =
       FutureConverters.toScala(client.submit(JournalUpdate(ref, cell)))
     
-    def lookup(ref: Reference) = 
+    def lookup(ref: Reference): Future[Option[Reference]] = 
       FutureConverters.toScala(client.submit(JournalLookup(ref)))
     
-    def currentBlock =
+    def currentBlock: Future[JournalBlock] =
       FutureConverters.toScala(client.submit(JournalCurrentBlock()))
     
     // JournalClient

--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -1,16 +1,18 @@
 package io.mediachain.transactor
 
 import java.io.File
-import java.util.function.Supplier
+import java.util.function.{Consumer, Supplier}
 import io.atomix.copycat.client.CopycatClient
 import io.atomix.copycat.server.{CopycatServer, StateMachine => CopycatStateMachine}
 import io.atomix.copycat.server.storage.{Storage, StorageLevel}
 import io.atomix.catalyst.transport.{Address, NettyTransport}
 import io.atomix.catalyst.serializer.Serializer
 
+import scala.compat.java8.FutureConverters
+
 object Copycat {
-  import io.mediachain.transactor.StateMachine.JournalStateMachine
-  import io.mediachain.transactor.Types.Datastore
+  import io.mediachain.transactor.StateMachine._
+  import io.mediachain.transactor.Types._
 
   object Server {
     def build(address: Address, logdir: String, datastore: Datastore,
@@ -38,15 +40,61 @@ object Copycat {
     }
   }
   
+  class Client(client: CopycatClient) extends JournalClient {
+    private var listeners: Set[JournalListener] = Set()
+    
+    // Journal 
+    def insert(rec: CanonicalRecord) =
+      FutureConverters.toScala(client.submit(JournalInsert(rec)))
+
+    def update(ref: Reference, cell: ChainCell) =
+      FutureConverters.toScala(client.submit(JournalUpdate(ref, cell)))
+    
+    def lookup(ref: Reference) = 
+      FutureConverters.toScala(client.submit(JournalLookup(ref)))
+    
+    def currentBlock =
+      FutureConverters.toScala(client.submit(JournalCurrentBlock()))
+    
+    // JournalClient
+    def connect(address: String) {
+      client.connect(new Address(address)).join()
+    }
+    
+    def close() {
+      client.close().join()
+    }
+    
+    def listen(listener: JournalListener) {
+      if (listeners.isEmpty) {
+        listeners = Set(listener)
+        client.onEvent("journal-commit", 
+          new Consumer[JournalCommitEvent] { 
+            def accept(evt: JournalCommitEvent) {
+              listeners.foreach(_.onJournalCommit(evt.entry))
+            }
+        })
+        client.onEvent("journal-block", 
+          new Consumer[JournalBlockEvent] { 
+            def accept(evt: JournalBlockEvent) { 
+              listeners.foreach(_.onJournalBlock(evt.ref))
+            }
+        })
+      } else {
+        listeners += listener
+      }
+    }
+  }
+
   object Client {
-    def build(): CopycatClient = {
+    def build(): Client = {
       val client = CopycatClient.builder()
                     .withTransport(NettyTransport.builder()
                                     .withThreads(2)
                                     .build())
                     .build()
       Serializers.register(client.serializer)
-      client
+      new Client(client)
     }
     
   }

--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -8,7 +8,10 @@ import io.atomix.copycat.server.storage.{Storage, StorageLevel}
 import io.atomix.catalyst.transport.{Address, NettyTransport}
 import io.atomix.catalyst.serializer.Serializer
 
+import scala.concurrent.Future
 import scala.compat.java8.FutureConverters
+
+import cats.data.Xor
 
 object Copycat {
   import io.mediachain.transactor.StateMachine._

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,6 +1,7 @@
 package io.mediachain.transactor
 
 object Types {
+  import scala.concurrent.Future
   import cats.data.Xor
   import org.json4s.JValue
 
@@ -95,15 +96,21 @@ object Types {
   
   // Journal transactor interface
   trait Journal {
-    def insert(rec: CanonicalRecord): Xor[JournalError, CanonicalEntry]
-    def update(ref: Reference, cell: ChainCell): Xor[JournalError, ChainEntry]
-    def lookup(ref: Reference): Option[Reference]
-    def currentBlock: JournalBlock
+    def insert(rec: CanonicalRecord): Future[Xor[JournalError, CanonicalEntry]]
+    def update(ref: Reference, cell: ChainCell): Future[Xor[JournalError, ChainEntry]]
+    def lookup(ref: Reference): Future[Option[Reference]]
+    def currentBlock: Future[JournalBlock]
   }
   
-  trait JournalClient {
-    def updateJournal(entry: JournalEntry): Unit
-    def updateJournalBlockchain(ref: Reference): Unit
+  trait JournalClient extends Journal {
+    def connect(address: String): Unit
+    def close(): Unit
+    def listen(listener: JournalListener): Unit
+  }
+  
+  trait JournalListener {
+    def onJournalCommit(entry: JournalEntry): Unit
+    def onJournalBlock(ref: Reference): Unit
   }
   
   sealed abstract class JournalError extends Serializable

--- a/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
@@ -1,26 +1,23 @@
 package io.mediachain.transactor
 
-import io.atomix.copycat.client.CopycatClient
 import io.atomix.copycat.server.CopycatServer
-import io.atomix.catalyst.transport.Address
 
 case class DummyContext(
   server: CopycatServer, 
-  client: CopycatClient, 
+  client: Types.JournalClient, 
   store: Dummies.DummyStore,
   logdir: String
 )
 
 object DummyContext {
-  def setup(srvaddr: String, blocksize: Int = StateMachine.JournalBlockSize) = {
+  def setup(address: String, blocksize: Int = StateMachine.JournalBlockSize) = {
     println("*** SETUP DUMMY COPYCAT CONTEXT")
     val logdir = setupLogdir()
-    val address = new Address(srvaddr)
     val store = new Dummies.DummyStore
     val server = Copycat.Server.build(address, logdir, store, blocksize)
     server.bootstrap().join()
     val client = Copycat.Client.build()
-    client.connect(address).join()
+    client.connect(address)
     DummyContext(server, client, store, logdir)
   }
   
@@ -38,7 +35,7 @@ object DummyContext {
   
   def shutdown(context: DummyContext) {
     println("*** SHUT DOWN DUMMY COPYCAT CONTEXT")
-    context.client.close().join()
+    context.client.close()
     context.server.shutdown().join()
     cleanupLogdir(context.logdir)
   }

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec.scala
@@ -53,7 +53,7 @@ object JournalBlockchainSpec extends io.mediachain.BaseSpec
       context.entityRef = entry.ref
     })
     val ref = context.entityRef
-    for (x <- 1 to 5) {
+    for (_ <- 1 to 5) {
       val op = context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
       val res = Await.result(op, timeout)
       res.foreach((entry: ChainEntry) => {context.entries += entry})
@@ -69,7 +69,7 @@ object JournalBlockchainSpec extends io.mediachain.BaseSpec
   def generateBlock = {
     val context = JournalBlockchainSpecContext.context
     val ref = context.entityRef
-    for (x <- 6 to (JournalBlockchainSpecContext.BlockSize - 1)) {
+    for (_ <- 6 to (JournalBlockchainSpecContext.BlockSize - 1)) {
       val op = context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
       val res = Await.result(op, timeout)
       res.foreach((entry: ChainEntry) => {context.entries += entry})
@@ -95,7 +95,7 @@ object JournalBlockchainSpec extends io.mediachain.BaseSpec
     val context = JournalBlockchainSpecContext.context
     val ref = context.entityRef
     context.entries = new ListBuffer
-    for (x <- 1 to JournalBlockchainSpecContext.BlockSize) {
+    for (_ <- 1 to JournalBlockchainSpecContext.BlockSize) {
       val op = context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
       val res = Await.result(op, timeout)
       res.foreach((entry: ChainEntry) => {context.entries += entry})

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
@@ -36,7 +36,7 @@ object JournalBlockchainSpec2 extends io.mediachain.BaseSpec
     val res = Await.result(op, timeout)
     res.foreach((entry: CanonicalEntry) => {
       val ref = entry.ref
-      for (x <- 1 to (JournalBlockSize - 1)) {
+      for (_ <- 1 to (JournalBlockSize - 1)) {
         context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
       }})
     val blockref = context.queue.poll(300, TimeUnit.SECONDS)

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
@@ -2,18 +2,20 @@ package io.mediachain.transactor
 
 import org.specs2.specification.{AfterAll, BeforeAll}
 
-import java.util.function.Consumer
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
-
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import scala.collection.mutable.ListBuffer
 
 import Types._
-import StateMachine._
+import StateMachine.JournalBlockSize
 
 object JournalBlockchainSpec2 extends io.mediachain.BaseSpec
   with BeforeAll
   with AfterAll
 {
+  val timeout = Duration(5, TimeUnit.SECONDS)
+  
   def is =
   s2"""
   JournalStateMachine generates Journal blocks
@@ -30,11 +32,12 @@ object JournalBlockchainSpec2 extends io.mediachain.BaseSpec
   
   def generateBlock = {
     val context = JournalBlockchainSpec2Context.context
-    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    val op = context.dummy.client.insert(Entity(Map()))
+    val res = Await.result(op, timeout)
     res.foreach((entry: CanonicalEntry) => {
       val ref = entry.ref
       for (x <- 1 to (JournalBlockSize - 1)) {
-        context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map())))
+        context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
       }})
     val blockref = context.queue.poll(300, TimeUnit.SECONDS)
     val block = context.dummy.store.get(blockref)
@@ -52,11 +55,11 @@ object JournalBlockchainSpec2Context {
   def setup(): Unit = {
     val dummy = DummyContext.setup("127.0.0.1:10003")
     val queue = new LinkedBlockingQueue[Reference]
-    dummy.client.onEvent("journal-block", 
-      new Consumer[JournalBlockEvent] { 
-        def accept(evt: JournalBlockEvent) { 
-          queue.offer(evt.ref)
-        }
+    dummy.client.listen(new JournalListener {
+      def onJournalBlock(ref: Reference) {
+          queue.offer(ref)
+      }
+      def onJournalCommit(entry: JournalEntry) {}
     })
     instance = new JournalBlockchainSpec2Context(dummy, queue)
   }

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalIndexSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalIndexSpec.scala
@@ -1,14 +1,18 @@
 package io.mediachain.transactor
 
 import org.specs2.specification.{AfterAll, BeforeAll}
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 import Types._
-import StateMachine._
 
 object JournalIndexSpec extends io.mediachain.BaseSpec
   with BeforeAll
   with AfterAll
 {
+  
+  val timeout = Duration(5, TimeUnit.SECONDS)
   
   def is =
     sequential ^
@@ -38,7 +42,8 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
 
   def insertEntity = {
     val context = JournalIndexSpecContext.context
-    val res = context.dummy.client.submit(JournalInsert(Entity(Map()))).join()
+    val op = context.dummy.client.insert(Entity(Map()))
+    val res = Await.result(op, timeout)
     res.foreach((entry: CanonicalEntry) => {context.entityRef = entry.ref})
     res must beRightXor
   }
@@ -46,14 +51,16 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
   def resolveEntityEmpty = {
     val context = JournalIndexSpecContext.context
     val ref = context.entityRef
-    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    val op = context.dummy.client.lookup(ref)
+    val res = Await.result(op, timeout)
     res must beNone
   }
   
   def extendEntityChain = {
     val context = JournalIndexSpecContext.context
     val ref = context.entityRef
-    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    val op = context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
+    val res = Await.result(op, timeout)
     res.foreach((entry: ChainEntry) => {context.entityChainRef = entry.chain})
     res must beRightXor { (entry: ChainEntry) =>
       (entry.ref must_== ref) and 
@@ -65,7 +72,8 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val context = JournalIndexSpecContext.context
     val ref = context.entityRef
     val chainRef = context.entityChainRef
-    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    val op = context.dummy.client.lookup(ref)
+    val res = Await.result(op, timeout)
     (res must beSome) and 
     (res.get must_== chainRef)
   }
@@ -74,7 +82,8 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val context = JournalIndexSpecContext.context
     val ref = context.entityRef
     val chainRef = context.entityChainRef
-    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    val op = context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
+    val res = Await.result(op, timeout)
     res.foreach((entry: ChainEntry) => {context.entityChainRef = entry.chain})
     res must beRightXor { (entry: ChainEntry) =>
       (entry.ref must_== ref) and 
@@ -85,7 +94,8 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
   
   def insertArtefact = {
     val context = JournalIndexSpecContext.context
-    val res = context.dummy.client.submit(JournalInsert(Artefact(Map()))).join()
+    val op = context.dummy.client.insert(Artefact(Map()))
+    val res = Await.result(op, timeout)
     res.foreach((entry: CanonicalEntry) => {context.artefactRef = entry.ref})
     res must beRightXor
   }
@@ -93,14 +103,16 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
   def resolveArtefactEmpty = {
     val context = JournalIndexSpecContext.context
     val ref = context.artefactRef
-    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    val op = context.dummy.client.lookup(ref)
+    val res = Await.result(op, timeout)
     res must beNone
   }
   
   def extendArtefactChain = {
     val context = JournalIndexSpecContext.context
     val ref = context.artefactRef
-    val res = context.dummy.client.submit(JournalUpdate(ref, ArtefactChainCell(ref, None, Map()))).join()
+    val op = context.dummy.client.update(ref, ArtefactChainCell(ref, None, Map()))
+    val res = Await.result(op, timeout)
     res.foreach((entry: ChainEntry) => {context.artefactChainRef = entry.chain})
     res must beRightXor { (entry: ChainEntry) =>
       (entry.ref must_== ref) and 
@@ -112,7 +124,8 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val context = JournalIndexSpecContext.context
     val ref = context.artefactRef
     val chainRef = context.artefactChainRef
-    val res = context.dummy.client.submit(JournalLookup(ref)).join()
+    val op = context.dummy.client.lookup(ref)
+    val res = Await.result(op, timeout)
     (res must beSome) and 
     (res.get must_== chainRef)
   }
@@ -121,7 +134,8 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val context = JournalIndexSpecContext.context
     val ref = context.artefactRef
     val chainRef = context.artefactChainRef
-    val res = context.dummy.client.submit(JournalUpdate(ref, ArtefactChainCell(ref, None, Map()))).join()
+    val op = context.dummy.client.update(ref, ArtefactChainCell(ref, None, Map()))
+    val res = Await.result(op, timeout)
     res.foreach((entry: ChainEntry) => {context.artefactChainRef = entry.chain})
     res must beRightXor { (entry: ChainEntry) =>
       (entry.ref must_== ref) and 
@@ -133,14 +147,16 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
   def checkEntityXCons = {
     val context = JournalIndexSpecContext.context
     val ref = context.entityRef
-    val res = context.dummy.client.submit(JournalUpdate(ref, ArtefactChainCell(ref, None, Map()))).join()
+    val op = context.dummy.client.update(ref, ArtefactChainCell(ref, None, Map()))
+    val res = Await.result(op, timeout)
     res must beLeftXor
   }
   
   def checkArtefactXCons = {
     val context = JournalIndexSpecContext.context
     val ref = context.artefactRef
-    val res = context.dummy.client.submit(JournalUpdate(ref, EntityChainCell(ref, None, Map()))).join()
+    val op = context.dummy.client.update(ref, EntityChainCell(ref, None, Map()))
+    val res = Await.result(op, timeout)
     res must beLeftXor
   }
 }


### PR DESCRIPTION
Fleshes out the interface for Journal clients and event listeners and refactors the tests to use it.

Specifics:
- futurize Journal interface methods
- add JournalClient < Journal interface for client objects
- rename JournalClient to JournalListener
- add Copycat.Client class implementing JournalClient
- refactor tests to use the JournalClient interface 
