### PR TITLE
CBOR serialization with cbor-java

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ object MediachainBuild extends Build {
     scalacOptions ++= Seq("-Xlint", "-deprecation", "-Xfatal-warnings", "-feature"),
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats" % "0.4.1",
-      "org.json4s" %% "json4s-jackson" % "3.2.11",
+      "org.json4s" %% "json4s-jackson" % "3.3.0",
       "org.specs2" %% "specs2-core" % "3.7" % "test",
       "org.specs2" %% "specs2-junit" % "3.7" % "test",
       "org.specs2" %% "specs2-matcher-extra" % "3.7" % "test",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,6 +4,9 @@ import Keys._
 object MediachainBuild extends Build {
   updateOptions := updateOptions.value.withCachedResolution(true)
 
+  val specs2Version = "3.7.3"
+  val scalaCheckVersion = "1.13.1"
+
   override lazy val settings = super.settings ++ Seq(
     organization := "io.mediachain",
     version := "0.0.1",
@@ -12,10 +15,11 @@ object MediachainBuild extends Build {
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats" % "0.4.1",
       "org.json4s" %% "json4s-jackson" % "3.3.0",
-      "org.specs2" %% "specs2-core" % "3.7" % "test",
-      "org.specs2" %% "specs2-junit" % "3.7" % "test",
-      "org.specs2" %% "specs2-matcher-extra" % "3.7" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.13.0" % "test",
+      "org.specs2" %% "specs2-core" % specs2Version % "test",
+      "org.specs2" %% "specs2-junit" % specs2Version % "test",
+      "org.specs2" %% "specs2-matcher-extra" % specs2Version % "test",
+      "org.specs2" %% "specs2-scalacheck" % specs2Version % "test",
+      "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
       "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0-RC1"
     ),
     scalacOptions in Test ++= Seq("-Yrangepos")

--- a/transactor/build.sbt
+++ b/transactor/build.sbt
@@ -6,5 +6,6 @@ libraryDependencies ++= Seq(
  "io.atomix.copycat" % "copycat-client" % "1.0.0-rc7",
  "io.atomix.catalyst" % "catalyst-netty" % "1.0.7",
  "org.slf4j" % "slf4j-api" % "1.7.21",
- "org.slf4j" % "slf4j-simple" % "1.7.21"
+ "org.slf4j" % "slf4j-simple" % "1.7.21",
+ "co.nstant.in" % "cbor" % "0.7"
 )

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -14,9 +14,8 @@ object Dummies {
     override def hashCode = num
     override def toString = "dummy@" + num
 
-    val CBORType = "dummyReference"
-    override def toCbor =
-      toCMapWithDefaults(Map("@link" -> CLong(num)), Map())
+    val CBORType = "" // unused
+    override def toCbor = CMap.withStringKeys("@link" -> CString(this.toString))
   }
   
   class DummyStore extends Datastore {

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable.{Map => MMap, HashMap => MHashMap}
 
 object Dummies {
   import io.mediachain.transactor.Types._
+  import io.mediachain.util.cbor._
   
   class DummyReference(val num: Int) extends Reference {
     override def equals(that: Any) = {
@@ -12,6 +13,10 @@ object Dummies {
     }
     override def hashCode = num
     override def toString = "dummy@" + num
+
+    val CBORType = "dummyReference"
+    override def toCbor =
+      toCMapWithDefaults(Map("@link" -> CLong(num)), Map())
   }
   
   class DummyStore extends Datastore {

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable.{Map => MMap, HashMap => MHashMap}
 
 object Dummies {
   import io.mediachain.transactor.Types._
-  import io.mediachain.util.cbor._
+  import io.mediachain.util.cbor.CborAST._
   
   class DummyReference(val num: Int) extends Reference {
     override def equals(that: Any) = {

--- a/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
@@ -1,0 +1,164 @@
+package io.mediachain.transactor
+
+import io.mediachain.transactor.Dummies.DummyReference
+
+
+object TypeSerialization {
+
+  import cats.data.Xor
+  import io.mediachain.transactor.Types._
+  import io.mediachain.util.cbor.CborAST._
+  import io.mediachain.util.cbor.CborCodec
+
+  object CBORTypeNames {
+    val Entity = "entity"
+    val Artefact = "artefact"
+    val EntityChainReference = "entityChainReference"
+    val ArtefactChainReference = "artefactChainReference"
+    val EntityChainCell = "entityChainCell"
+    val ArtefactChainCell = "artefactChainCell"
+    val CanonicalEntry = "insert"
+    val ChainEntry = "update"
+    val JournalBlock = "journalBlock"
+  }
+
+  sealed trait DeserializationError
+
+  case class CborDecodingFailed() extends DeserializationError
+
+  case class UnexpectedCborType(message: String) extends DeserializationError
+
+  case class ReferenceDecodingFailed(message: String) extends DeserializationError
+
+  case class TypeNameNotFound() extends DeserializationError
+
+  case class UnknownDataObjectType(typeName: String) extends DeserializationError
+
+  case class RequiredFieldNotFound(fieldName: String) extends DeserializationError
+
+  def fromCborBytes(bytes: Array[Byte]): Xor[DeserializationError, DataObject] =
+    CborCodec.decode(bytes) match {
+      case (cValue: CValue) :: _ => fromCbor(cValue)
+      case Nil => Xor.left(CborDecodingFailed())
+    }
+
+  def fromCbor(cValue: CValue): Xor[DeserializationError, DataObject] =
+    cValue match {
+      case (cMap: CMap) => fromCMap(cMap)
+      case _ => Xor.left(UnexpectedCborType(
+        s"Expected CBOR map, but received ${cValue.getClass.getName}"
+      ))
+    }
+
+  def fromCMap(cMap: CMap): Xor[DeserializationError, DataObject] = {
+    val typeNameOpt: Option[String] =
+      cMap.getAs[CString]("type").map(_.string)
+
+    Xor.fromOption(typeNameOpt, TypeNameNotFound())
+      .flatMap(name => fromCMap(cMap, name))
+  }
+
+
+
+  def fromCMap(cMap: CMap, typeName: String)
+  : Xor[DeserializationError, DataObject] = typeName match {
+      case CBORTypeNames.Entity =>
+        Xor.right(Entity(meta = cMap.asStringKeyedMap - "type"))
+
+      case CBORTypeNames.Artefact =>
+        Xor.right(Artefact(meta = cMap.asStringKeyedMap - "type"))
+
+      case CBORTypeNames.EntityChainCell =>
+        entityChainCellFromCMap(cMap)
+
+      case CBORTypeNames.ArtefactChainCell =>
+        artefactChainCellFromCMap(cMap)
+
+      case _ => Xor.left(UnknownDataObjectType(typeName))
+    }
+
+
+  def entityChainCellFromCMap(cMap: CMap)
+  : Xor[DeserializationError, EntityChainCell] = {
+    val entityXor = getRequiredReference(cMap, "entity")
+    entityXor.map { entityRef: Reference =>
+      EntityChainCell(
+        entity = entityRef,
+        chain = getOptionalReference(cMap, "chain"),
+        meta = cMap.asStringKeyedMap -- Seq("type", "entity", "chain")
+      )
+    }
+  }
+
+  def artefactChainCellFromCMap(cMap: CMap)
+  : Xor[DeserializationError, ArtefactChainCell] = {
+    val artefactXor = getRequiredReference(cMap, "artefact")
+    artefactXor.map { artefactRef: Reference =>
+      ArtefactChainCell(
+        artefact = artefactRef,
+        chain = getOptionalReference(cMap, "chain"),
+        meta = cMap.asStringKeyedMap -- Seq("type", "artefact", "chain")
+      )
+    }
+  }
+
+
+  def canonicalEntryFromCMap(cMap: CMap)
+  : Xor[DeserializationError, CanonicalEntry] =
+    for {
+      index <- getRequired[CInt](cMap, "index").map(_.num)
+      ref <- getRequiredReference(cMap, "ref")
+    } yield CanonicalEntry(index, ref)
+
+
+  def chainEntryFromCMap(cMap: CMap)
+  : Xor[DeserializationError, ChainEntry] =
+    for {
+      index <- getRequired[CInt](cMap, "index").map(_.num)
+      ref <- getRequiredReference(cMap, "ref")
+      chain <- getRequiredReference(cMap, "chain")
+    } yield ChainEntry(
+      index = index,
+      ref = ref,
+      chain = chain,
+      chainPrevious = getOptionalReference(cMap, "chainPrevious")
+    )
+
+  def getRequired[T <: CValue](cMap: CMap, fieldName: String)
+  : Xor[RequiredFieldNotFound, T] = Xor.fromOption(
+    cMap.getAs[T](fieldName),
+    RequiredFieldNotFound(fieldName)
+  )
+
+
+  def getRequiredReference(cMap: CMap, fieldName: String)
+  : Xor[DeserializationError, Reference] =
+    getRequired[CMap](cMap, fieldName)
+    .flatMap(referenceFromCMap)
+
+
+  def getOptionalReference(cMap: CMap, fieldName: String): Option[Reference] =
+    cMap.getAs[CMap](fieldName)
+      .flatMap(referenceFromCMap(_).toOption)
+
+
+
+  def referenceFromCMap(cMap: CMap): Xor[DeserializationError, Reference] = {
+    val linkOpt: Option[CValue] =
+      cMap.asStringKeyedMap.get("@link")
+
+    Xor.fromOption(linkOpt, ReferenceDecodingFailed("@link field not found"))
+      .flatMap(decodeLinkValue)
+  }
+
+
+  def decodeLinkValue(linkVal: CValue): Xor[DeserializationError, Reference] =
+    linkVal match {
+      case CString(s) if s.startsWith("dummy@") => {
+        val seqno = s.substring("dummy@".length).toInt
+        Xor.right(new DummyReference(seqno))
+      }
+      case _ =>
+        Xor.left(ReferenceDecodingFailed(s"Unknown link value $linkVal"))
+    }
+}

--- a/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
@@ -55,7 +55,7 @@ object TypeSerialization {
       case Xor.Right(journalEntry: JournalEntry) => Xor.right(journalEntry)
       case Xor.Right(unknownObject) =>
         Xor.left(UnexpectedCborType(
-          s"Expected DataObject, but got ${unknownObject.getClass.getTypeName}"
+          s"Expected JournalEntry, but got ${unknownObject.getClass.getTypeName}"
         ))
     }
 

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -8,7 +8,7 @@ object Types {
   import io.mediachain.util.cbor._
 
   // Base class of all objects storable in the Datastore
-  sealed abstract class DataObject extends Serializable
+  sealed abstract class DataObject extends Serializable with ToCbor
 
   trait ToCbor {
     val CBORType: String
@@ -40,19 +40,26 @@ object Types {
   abstract class Reference extends Serializable with ToCbor
 
   // Typed References for tracking chain heads in the StateMachine
-  sealed abstract class ChainReference extends Serializable {
+  sealed abstract class ChainReference extends Serializable with ToCbor {
     def chain: Option[Reference]
+
+    override def toCbor =
+      toCMapWithDefaults(Map(), Map("chain" -> chain.map(_.toCbor)))
   }
 
   case class EntityChainReference(chain: Option[Reference])
-    extends ChainReference
+    extends ChainReference {
+    val CBORType = "entityChainReference"
+  }
 
   object EntityChainReference {
     def empty = EntityChainReference(None)
   }
 
   case class ArtefactChainReference(chain: Option[Reference])
-    extends ChainReference
+    extends ChainReference {
+    val CBORType = "artefactChainReference"
+  }
 
   object ArtefactChainReference {
     def empty = ArtefactChainReference(None)
@@ -66,12 +73,20 @@ object Types {
   case class Entity(
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
+    val CBORType = "entity"
+    override def toCbor =
+      super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
+
     def reference: ChainReference = EntityChainReference.empty
   }
   
   case class Artefact( 
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
+    val CBORType = "entity"
+    override def toCbor =
+      super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
+    
     def reference: ChainReference = ArtefactChainReference.empty
   }
   
@@ -84,16 +99,32 @@ object Types {
     entity: Reference,
     chain: Option[Reference],
     meta: Map[String, CValue]
-  ) extends ChainCell
+  ) extends ChainCell {
+    val CBORType = "entityChainCell"
+
+    override def toCbor = {
+      val defaults = meta + ("entity" -> entity.toCbor)
+      val optionals = Map("chain" -> chain.map(_.toCbor))
+      super.toCMapWithDefaults(defaults, optionals)
+    }
+  }
   
   case class ArtefactChainCell( 
     artefact: Reference,
     chain: Option[Reference],
     meta: Map[String, CValue]
-  ) extends ChainCell
+  ) extends ChainCell {
+    val CBORType = "artefactChainCell"
+
+    override def toCbor = {
+      val defaults = meta + ("artefact" -> artefact.toCbor)
+      val optionals = Map("chain" -> chain.map(_.toCbor))
+      super.toCMapWithDefaults(defaults, optionals)
+    }
+  }
   
   // Journal Entries
-  sealed abstract class JournalEntry extends Serializable {
+  sealed abstract class JournalEntry extends Serializable with ToCbor {
     def index: BigInt
     def ref: Reference
   }
@@ -101,7 +132,7 @@ object Types {
   case class CanonicalEntry( 
     index: BigInt,
     ref: Reference
-  ) extends JournalEntry with ToCbor {
+  ) extends JournalEntry {
     val CBORType = "insert"
 
     override def toCbor: CValue = {
@@ -119,7 +150,7 @@ object Types {
     ref: Reference,
     chain: Reference,
     chainPrevious: Option[Reference]
-  ) extends JournalEntry with ToCbor {
+  ) extends JournalEntry {
     val CBORType = "update"
 
     override def toCbor: CValue = {
@@ -140,7 +171,16 @@ object Types {
     index: BigInt,
     chain: Option[Reference],
     entries: Array[JournalEntry]
-  ) extends DataObject
+  ) extends DataObject {
+    val CBORType = "journalBlock"
+
+    override def toCbor = {
+      val cborEntries = CArray(entries.map(_.toCbor).toList)
+      val defaults = Map("index" -> CInt(index), "entries" -> cborEntries)
+      val optionals = Map("chain" -> chain.map(_.toCbor))
+      super.toCMapWithDefaults(defaults, optionals)
+    }
+  }
 
 
   // Journal transactor interface

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -11,9 +11,9 @@ object Types {
   import io.mediachain.util.cbor.CborAST._
 
   // Base class of all objects storable in the Datastore
-  sealed abstract class DataObject extends Serializable with ToCbor
+  sealed abstract class DataObject extends Serializable with CborSerializable
 
-  trait ToCbor {
+  trait CborSerializable {
     val CBORType: String
 
     def toCborBytes: Array[Byte] = CborCodec.encode(toCbor)
@@ -40,10 +40,10 @@ object Types {
   }
 
   // References to records in the underlying datastore
-  abstract class Reference extends Serializable with ToCbor
+  abstract class Reference extends Serializable with CborSerializable
 
   // Typed References for tracking chain heads in the StateMachine
-  sealed abstract class ChainReference extends Serializable with ToCbor {
+  sealed abstract class ChainReference extends Serializable with CborSerializable {
     def chain: Option[Reference]
 
     override def toCbor =
@@ -127,8 +127,7 @@ object Types {
   }
   
   // Journal Entries
-  sealed abstract class JournalEntry extends DataObject
-    with Serializable with ToCbor {
+  sealed abstract class JournalEntry extends Serializable with CborSerializable {
     def index: BigInt
     def ref: Reference
   }

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -127,7 +127,8 @@ object Types {
   }
   
   // Journal Entries
-  sealed abstract class JournalEntry extends Serializable with ToCbor {
+  sealed abstract class JournalEntry extends DataObject
+    with Serializable with ToCbor {
     def index: BigInt
     def ref: Reference
   }

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -3,10 +3,31 @@ package io.mediachain.transactor
 object Types {
   import scala.concurrent.Future
   import cats.data.Xor
-  import org.json4s.JValue
+
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable
+
+  import org.json4s.{JValue, JObject, JString, JField}
+
+  trait ToJObject {
+    val CBORType: String
+
+    def toJObject: JObject =
+      toJObjectWithDefaults(Map.empty, Map.empty)
+
+    def toJObjectWithDefaults(defaults: Map[String, JValue],
+                              optionals: Map[String, Option[JValue]]):
+    JObject = {
+      val merged = defaults ++ optionals.flatMap {
+        case (_, None) => List.empty
+        case (k, Some(v)) => List(k -> v)
+      }
+      val withType = ("type", JString(CBORType)) :: merged.toList
+
+      JObject(withType)
+    }
+  }
 
   // Mediachain Datastore Records
   sealed abstract class Record extends DataObject {

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,32 +1,22 @@
 package io.mediachain.transactor
 
-import java.io.ByteArrayOutputStream
-
 
 object Types {
   import scala.concurrent.Future
   import cats.data.Xor
 
+  import io.mediachain.util.cbor._
+  import org.json4s.{JValue, JObject, JString}
+  import io.mediachain.util.cbor.JValueConversions.jValueToCbor
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable
 
-  import org.json4s.{JValue, JObject, JString, JField}
-  import co.nstant.in.cbor.{model => Cbor}
-  import co.nstant.in.cbor.CborEncoder
-  import io.mediachain.util.cbor.JValueConversions.jValueToCbor
-
   trait ToJObject {
     val CBORType: String
 
-    def toCbor: Cbor.DataItem = jValueToCbor(toJObject)
-
-    def toCborBytes: Array[Byte] = {
-      val out = new ByteArrayOutputStream()
-      new CborEncoder(out).encode(toCbor)
-      out.close()
-      out.toByteArray
-    }
+    def toCbor: CValue = jValueToCbor(toJObject)
+    def toCborBytes: Array[Byte] = encode(toCbor)
 
     def toJObject: JObject =
       toJObjectWithDefaults(Map.empty, Map.empty)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,5 +1,7 @@
 package io.mediachain.transactor
 
+import io.mediachain.transactor.TypeSerialization.CBORTypeNames
+
 
 object Types {
   import scala.concurrent.Future
@@ -50,7 +52,7 @@ object Types {
 
   case class EntityChainReference(chain: Option[Reference])
     extends ChainReference {
-    val CBORType = "entityChainReference"
+    val CBORType = CBORTypeNames.EntityChainReference
   }
 
   object EntityChainReference {
@@ -59,7 +61,7 @@ object Types {
 
   case class ArtefactChainReference(chain: Option[Reference])
     extends ChainReference {
-    val CBORType = "artefactChainReference"
+    val CBORType = CBORTypeNames.ArtefactChainReference
   }
 
   object ArtefactChainReference {
@@ -74,7 +76,7 @@ object Types {
   case class Entity(
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = "entity"
+    val CBORType = CBORTypeNames.Entity
     override def toCbor =
       super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
 
@@ -84,7 +86,7 @@ object Types {
   case class Artefact( 
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = "entity"
+    val CBORType = CBORTypeNames.Artefact
     override def toCbor =
       super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
     
@@ -101,7 +103,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = "entityChainCell"
+    val CBORType = CBORTypeNames.EntityChainCell
 
     override def toCbor = {
       val defaults = meta + ("entity" -> entity.toCbor)
@@ -115,7 +117,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = "artefactChainCell"
+    val CBORType = CBORTypeNames.ArtefactChainCell
 
     override def toCbor = {
       val defaults = meta + ("artefact" -> artefact.toCbor)
@@ -134,7 +136,7 @@ object Types {
     index: BigInt,
     ref: Reference
   ) extends JournalEntry {
-    val CBORType = "insert"
+    val CBORType = CBORTypeNames.CanonicalEntry
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -152,7 +154,7 @@ object Types {
     chain: Reference,
     chainPrevious: Option[Reference]
   ) extends JournalEntry {
-    val CBORType = "update"
+    val CBORType = CBORTypeNames.ChainEntry
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -173,7 +175,7 @@ object Types {
     chain: Option[Reference],
     entries: Array[JournalEntry]
   ) extends DataObject {
-    val CBORType = "journalBlock"
+    val CBORType = CBORTypeNames.JournalBlock
 
     override def toCbor = {
       val cborEntries = CArray(entries.map(_.toCbor).toList)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -5,7 +5,8 @@ object Types {
   import scala.concurrent.Future
   import cats.data.Xor
 
-  import io.mediachain.util.cbor._
+  import io.mediachain.util.cbor.CborCodec
+  import io.mediachain.util.cbor.CborAST._
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable with ToCbor
@@ -13,7 +14,7 @@ object Types {
   trait ToCbor {
     val CBORType: String
 
-    def toCborBytes: Array[Byte] = encode(toCbor)
+    def toCborBytes: Array[Byte] = CborCodec.encode(toCbor)
 
     def toCbor: CValue =
       toCMapWithDefaults(Map.empty, Map.empty)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -6,39 +6,36 @@ object Types {
   import cats.data.Xor
 
   import io.mediachain.util.cbor._
-  import org.json4s.{JValue, JObject, JString}
-  import io.mediachain.util.cbor.JValueConversions.jValueToCbor
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable
 
-  trait ToJObject {
+  trait ToCbor {
     val CBORType: String
 
-    def toCbor: CValue = jValueToCbor(toJObject)
     def toCborBytes: Array[Byte] = encode(toCbor)
 
-    def toJObject: JObject =
-      toJObjectWithDefaults(Map.empty, Map.empty)
+    def toCbor: CValue =
+      toCMapWithDefaults(Map.empty, Map.empty)
 
-    def toJObjectWithDefaults(defaults: Map[String, JValue],
-                              optionals: Map[String, Option[JValue]]):
-    JObject = {
+    def toCMapWithDefaults(defaults: Map[String, CValue],
+                           optionals: Map[String, Option[CValue]])
+    : CMap = {
       val merged = defaults ++ optionals.flatMap {
         case (_, None) => List.empty
         case (k, Some(v)) => List(k -> v)
       }
-      val withType = ("type", JString(CBORType)) :: merged.toList
+      val withType = ("type", CString(CBORType)) :: merged.toList
 
-      JObject(withType)
+      CMap(withType)
     }
   }
 
   // Mediachain Datastore Records
   sealed abstract class Record extends DataObject {
-    def meta: Map[String, JValue]
+    def meta: Map[String, CValue]
   }
-  
+
   // References to records in the underlying datastore
   abstract class Reference extends Serializable
 
@@ -46,7 +43,7 @@ object Types {
   sealed abstract class ChainReference extends Serializable {
     def chain: Option[Reference]
   }
-  
+
   case class EntityChainReference(chain: Option[Reference])
     extends ChainReference
 
@@ -65,15 +62,15 @@ object Types {
   sealed abstract class CanonicalRecord extends Record {
     def reference: ChainReference
   }
-  
+
   case class Entity(
-    meta: Map[String, JValue]
+    meta: Map[String, CValue]
   ) extends CanonicalRecord {
     def reference: ChainReference = EntityChainReference.empty
   }
   
   case class Artefact( 
-    meta: Map[String, JValue]
+    meta: Map[String, CValue]
   ) extends CanonicalRecord {
     def reference: ChainReference = ArtefactChainReference.empty
   }
@@ -86,13 +83,13 @@ object Types {
   case class EntityChainCell( 
     entity: Reference,
     chain: Option[Reference],
-    meta: Map[String, JValue]
+    meta: Map[String, CValue]
   ) extends ChainCell
   
   case class ArtefactChainCell( 
     artefact: Reference,
     chain: Option[Reference],
-    meta: Map[String, JValue]
+    meta: Map[String, CValue]
   ) extends ChainCell
   
   // Journal Entries
@@ -104,22 +101,48 @@ object Types {
   case class CanonicalEntry( 
     index: BigInt,
     ref: Reference
-  ) extends JournalEntry
-  
+  ) extends JournalEntry with ToCbor {
+    val CBORType = "insert"
+
+    override def toCbor: CValue = {
+      val defaults = Map(
+        "index" -> CInt(index),
+        "ref"   -> CString(ref.toString)
+      )
+      super.toCMapWithDefaults(defaults, Map())
+    }
+  }
+
+
   case class ChainEntry( 
     index: BigInt,
     ref: Reference,
     chain: Reference,
     chainPrevious: Option[Reference]
-  ) extends JournalEntry
-  
+  ) extends JournalEntry with ToCbor {
+    val CBORType = "update"
+
+    override def toCbor: CValue = {
+      val defaults = Map(
+        "index" -> CInt(index),
+        "ref"   -> CString(ref.toString),
+        "chain" -> CString(chain.toString)
+      )
+      val prev = chainPrevious.map(x => CString(x.toString))
+      val optionals = Map("chainPrevious" -> prev)
+
+      super.toCMapWithDefaults(defaults, optionals)
+    }
+  }
+
   // Journal Blocks
   case class JournalBlock(
     index: BigInt,
     chain: Option[Reference],
     entries: Array[JournalEntry]
   ) extends DataObject
-  
+
+
   // Journal transactor interface
   trait Journal {
     def insert(rec: CanonicalRecord): Future[Xor[JournalError, CanonicalEntry]]

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -27,7 +27,7 @@ object Types {
       }
       val withType = ("type", CString(CBORType)) :: merged.toList
 
-      CMap(withType)
+      CMap.withStringKeys(withType)
     }
   }
 

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,5 +1,8 @@
 package io.mediachain.transactor
 
+import java.io.ByteArrayOutputStream
+
+
 object Types {
   import scala.concurrent.Future
   import cats.data.Xor
@@ -9,9 +12,21 @@ object Types {
   sealed abstract class DataObject extends Serializable
 
   import org.json4s.{JValue, JObject, JString, JField}
+  import co.nstant.in.cbor.{model => Cbor}
+  import co.nstant.in.cbor.CborEncoder
+  import io.mediachain.util.cbor.JValueConversions.jValueToCbor
 
   trait ToJObject {
     val CBORType: String
+
+    def toCbor: Cbor.DataItem = jValueToCbor(toJObject)
+
+    def toCborBytes: Array[Byte] = {
+      val out = new ByteArrayOutputStream()
+      new CborEncoder(out).encode(toCbor)
+      out.close()
+      out.toByteArray
+    }
 
     def toJObject: JObject =
       toJObjectWithDefaults(Map.empty, Map.empty)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -37,7 +37,7 @@ object Types {
   }
 
   // References to records in the underlying datastore
-  abstract class Reference extends Serializable
+  abstract class Reference extends Serializable with ToCbor
 
   // Typed References for tracking chain heads in the StateMachine
   sealed abstract class ChainReference extends Serializable {
@@ -107,7 +107,7 @@ object Types {
     override def toCbor: CValue = {
       val defaults = Map(
         "index" -> CInt(index),
-        "ref"   -> CString(ref.toString)
+        "ref"   -> ref.toCbor
       )
       super.toCMapWithDefaults(defaults, Map())
     }
@@ -125,10 +125,10 @@ object Types {
     override def toCbor: CValue = {
       val defaults = Map(
         "index" -> CInt(index),
-        "ref"   -> CString(ref.toString),
-        "chain" -> CString(chain.toString)
+        "ref"   -> ref.toCbor,
+        "chain" -> chain.toCbor
       )
-      val prev = chainPrevious.map(x => CString(x.toString))
+      val prev = chainPrevious.map(_.toCbor)
       val optionals = Map("chainPrevious" -> prev)
 
       super.toCMapWithDefaults(defaults, optionals)

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -1,15 +1,12 @@
-package io.mediachain.util
+package io.mediachain.util.cbor
 
 
-package object cbor {
-  import java.io.ByteArrayOutputStream
-
+object CborAST {
   import co.nstant.in.cbor.builder.AbstractBuilder
   import co.nstant.in.cbor.model.SimpleValueType
-  import co.nstant.in.cbor.{CborDecoder, CborEncoder, model => Cbor}
+  import co.nstant.in.cbor.{model => Cbor}
 
   import collection.JavaConverters._
-
 
   sealed trait CValue
   case class CNull() extends CValue
@@ -96,16 +93,6 @@ package object cbor {
 
     case _ => CUnhandled(item)
   }
-
-  def encode(cValue: CValue): Array[Byte] = {
-    val out = new ByteArrayOutputStream
-    new CborEncoder(out).encode(toDataItem(cValue))
-    out.close()
-    out.toByteArray
-  }
-
-  def decode(bytes: Array[Byte]): List[CValue] =
-    CborDecoder.decode(bytes).asScala.map(fromDataItem).toList
 
 
   private val converter = new DataItemConverter

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -15,7 +15,6 @@ object CborAST {
   case class CNull() extends CValue
   case class CUndefined() extends CValue
   case class CInt(num: BigInt) extends CValue
-  case class CLong(num: Long) extends CValue
   case class CDouble(num: Double) extends CValue
   case class CBool(bool: Boolean) extends CValue
   case class CString(string: String) extends CValue
@@ -65,7 +64,6 @@ object CborAST {
     case _: CNull => Cbor.SimpleValue.NULL
     case _: CUndefined => Cbor.SimpleValue.UNDEFINED
     case CInt(num) => converter.convert(num)
-    case CLong(num) => converter.convert(num)
     case CDouble(num) => converter.convert(num)
     case CBool(bool) => converter.convert(bool)
     case CString(string) => converter.convert(string)
@@ -88,6 +86,11 @@ object CborAST {
   }
 
   def fromDataItem(item: Cbor.DataItem): CValue = item match {
+      // match these first, since they're encoded as Arrays and would
+      // otherwise match CArray
+    case _: Cbor.LanguageTaggedString => CUnhandled(item)
+    case _: Cbor.RationalNumber => CUnhandled(item)
+
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.TRUE =>
       CBool(true)
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.FALSE =>

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -14,6 +14,7 @@ object CborAST {
   sealed trait CValue
   case class CNull() extends CValue
   case class CUndefined() extends CValue
+  case class CTag(tag: Long) extends CValue
   case class CInt(num: BigInt) extends CValue
   case class CDouble(num: Double) extends CValue
   case class CBool(bool: Boolean) extends CValue
@@ -63,6 +64,7 @@ object CborAST {
   def toDataItem(cValue: CValue): Cbor.DataItem = cValue match {
     case _: CNull => Cbor.SimpleValue.NULL
     case _: CUndefined => Cbor.SimpleValue.UNDEFINED
+    case CTag(tag) => new Cbor.Tag(tag)
     case CInt(num) => converter.convert(num)
     case CDouble(num) => converter.convert(num)
     case CBool(bool) => converter.convert(bool)
@@ -90,6 +92,8 @@ object CborAST {
       // otherwise match CArray
     case _: Cbor.LanguageTaggedString => CUnhandled(item)
     case _: Cbor.RationalNumber => CUnhandled(item)
+
+    case t: Cbor.Tag => CTag(t.getValue)
 
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.TRUE =>
       CBool(true)

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -28,11 +28,16 @@ object CborAST {
 
 
   object CMap {
+    def apply(fields: CField*): CMap = CMap(fields.toList)
+
     // would like to have used `apply` here, but thanks to type erasure
     // the JVM can't distinguish between a List[(CValue, CValue)] and a
     // List[(String, CValue)]
     def withStringKeys(stringFields: List[(String, CValue)]): CMap =
       CMap(stringFields.map(f => (CString(f._1), f._2)))
+
+    def withStringKeys(stringFields: (String, CValue)*): CMap =
+      withStringKeys(stringFields.toList)
   }
 
   def toDataItem(cValue: CValue): Cbor.DataItem = cValue match {

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborCodec.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborCodec.scala
@@ -1,0 +1,18 @@
+package io.mediachain.util.cbor
+
+object CborCodec {
+  import java.io.ByteArrayOutputStream
+  import co.nstant.in.cbor.{CborDecoder, CborEncoder}
+  import io.mediachain.util.cbor.CborAST._
+  import collection.JavaConverters._
+
+  def encode(cValue: CValue): Array[Byte] = {
+    val out = new ByteArrayOutputStream
+    new CborEncoder(out).encode(CborAST.toDataItem(cValue))
+    out.close()
+    out.toByteArray
+  }
+
+  def decode(bytes: Array[Byte]): List[CValue] =
+    CborDecoder.decode(bytes).asScala.map(CborAST.fromDataItem).toList
+}

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -4,7 +4,7 @@ package io.mediachain.util.cbor
 
 object JValueConversions {
   import org.json4s._
-
+  import io.mediachain.util.cbor.CborAST._
 
   def jValueToCbor(jValue: JValue): CValue = {
     jValue match {

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -46,14 +46,13 @@ object JValueConversions {
       }
 
       case JObject(fields) => {
-        val cborFields = fields.map { pair: (String, JValue) =>
-          val cborVal = jValueToCbor(pair._2)
-          val name = new Cbor.UnicodeString(pair._1)
-          (name, cborVal)
+        val cborMap = new Cbor.Map(fields.length)
+        fields.foreach { f: JField =>
+          cborMap.put(
+            new Cbor.UnicodeString(f._1),
+            jValueToCbor(f._2)
+          )
         }
-
-        val cborMap = new Cbor.Map(cborFields.length)
-        cborFields.foreach(f => cborMap.put(f._1, f._2))
         cborMap
       }
 

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -1,10 +1,10 @@
 package io.mediachain.util.cbor
 
-import co.nstant.in.cbor.CborBuilder
-import co.nstant.in.cbor.{model => Cbor}
-import org.json4s._
 
 object JValueConversions {
+  import co.nstant.in.cbor.CborBuilder
+  import co.nstant.in.cbor.{model => Cbor}
+  import org.json4s._
   import collection.JavaConverters._
 
   private def firstItem(builder: CborBuilder): Cbor.DataItem =

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -11,7 +11,7 @@ object JValueConversions {
       case JNull => CNull()
       case JNothing => CUndefined()
       case JInt(num) => CInt(num)
-      case JLong(num) => CLong(num)
+      case JLong(num) => CInt(num)
       case JDecimal(num) => CDouble(num.doubleValue)
       case JDouble(num) => CDouble(num)
       case JBool(b) => CBool(b)

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -1,50 +1,23 @@
 package io.mediachain.util.cbor
 
 
+
 object JValueConversions {
-  import co.nstant.in.cbor.builder.AbstractBuilder
-  import co.nstant.in.cbor.{model => Cbor}
   import org.json4s._
 
-  // Provides access to protected `convert` methods on `AbstractBuilder`
-  private class StatelessBuilder extends AbstractBuilder[Object](null) {
-    def convertNumber(num: BigInt) = super.convert(num.bigInteger)
-    def convertNumber(num: BigDecimal) = super.convert(num.doubleValue)
-    def convertNumber(num: Long) = super.convert(num)
-    def convertNumber(num: Double) = super.convert(num)
-    def convertBool(boolean: Boolean) = super.convert(boolean)
-    def convertString(string: String) = super.convert(string)
-  }
 
-
-  def jValueToCbor(jValue: JValue): Cbor.DataItem = {
-    val builder = new StatelessBuilder
+  def jValueToCbor(jValue: JValue): CValue = {
     jValue match {
-      case JNull => Cbor.SimpleValue.NULL
-      case JNothing => Cbor.SimpleValue.UNDEFINED
-      case JInt(num) => builder.convertNumber(num)
-      case JLong(num) => builder.convertNumber(num)
-      case JDecimal(num) => builder.convertNumber(num)
-      case JDouble(num) => builder.convertNumber(num)
-      case JBool(b) => builder.convertBool(b)
-      case JString(s) => builder.convertString(s)
-
-      case JArray(arr) => {
-        val cborArr = new Cbor.Array(arr.length)
-        arr.foreach(jValue => cborArr.add(jValueToCbor(jValue)))
-        cborArr
-      }
-
-      case JObject(fields) => {
-        val cborMap = new Cbor.Map(fields.length)
-        fields.foreach { f: JField =>
-          cborMap.put(
-            builder.convertString(f._1),
-            jValueToCbor(f._2)
-          )
-        }
-        cborMap
-      }
+      case JNull => CNull()
+      case JNothing => CUndefined()
+      case JInt(num) => CInt(num)
+      case JLong(num) => CLong(num)
+      case JDecimal(num) => CDouble(num.doubleValue)
+      case JDouble(num) => CDouble(num)
+      case JBool(b) => CBool(b)
+      case JString(s) => CString(s)
+      case JArray(arr) => CArray(arr.map(jValueToCbor))
+      case JObject(fields) => CMap(fields.map(f => (f._1, jValueToCbor(f._2))))
     }
   }
 }

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -1,0 +1,64 @@
+package io.mediachain.util.cbor
+
+import co.nstant.in.cbor.CborBuilder
+import co.nstant.in.cbor.{model => Cbor}
+import org.json4s._
+
+object JValueConversions {
+  import scala.language.implicitConversions
+  import collection.JavaConverters._
+
+  private def firstItem(builder: CborBuilder): Cbor.DataItem =
+    builder.build().asScala.headOption.getOrElse {
+    throw new MappingException("Unable to convert JValue to CBOR")
+  }
+
+  implicit def jValueToCbor(jValue: JValue): Cbor.DataItem =
+    jValue match {
+      case JInt(num) => firstItem {
+        new CborBuilder().add(num.bigInteger)
+      }
+
+      case JLong(num) => firstItem {
+        new CborBuilder().add(num)
+      }
+
+      case JDecimal(num) => firstItem {
+        new CborBuilder().add(num.doubleValue())
+      }
+
+      case JDouble(num) => firstItem {
+        new CborBuilder().add(num)
+      }
+
+      case JBool(b) => firstItem {
+        new CborBuilder().add(b)
+      }
+
+      case JString(s) => firstItem {
+        new CborBuilder().add(s)
+      }
+
+      case JArray(arr) => {
+        val cborValues = arr.map(jValueToCbor)
+        val cborArr = new Cbor.Array(cborValues.length)
+        cborValues.foreach(cborArr.add)
+        cborArr
+      }
+
+      case JObject(fields) => {
+        val cborFields = fields.map { pair: (String, JValue) =>
+          val cborVal = jValueToCbor(pair._2)
+          val name = new Cbor.UnicodeString(pair._1)
+          (name, cborVal)
+        }
+
+        val cborMap = new Cbor.Map(cborFields.length)
+        cborFields.foreach(f => cborMap.put(f._1, f._2))
+        cborMap
+      }
+
+      case JNull => Cbor.SimpleValue.NULL
+      case JNothing => Cbor.SimpleValue.UNDEFINED
+    }
+}

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -7,36 +7,32 @@ object JValueConversions {
   import org.json4s._
   import collection.JavaConverters._
 
-  private def firstItem(builder: CborBuilder): Cbor.DataItem =
-    builder.build().asScala.headOption.getOrElse {
-    throw new MappingException("Unable to convert JValue to CBOR")
+  private implicit class BuilderHead(builder: CborBuilder) {
+    def head: Cbor.DataItem =
+      builder.build().asScala.headOption.getOrElse {
+        throw new MappingException("Unable to convert JValue to CBOR")
+      }
   }
 
   def jValueToCbor(jValue: JValue): Cbor.DataItem =
     jValue match {
-      case JInt(num) => firstItem {
-        new CborBuilder().add(num.bigInteger)
-      }
+      case JInt(num) =>
+        new CborBuilder().add(num.bigInteger).head
 
-      case JLong(num) => firstItem {
-        new CborBuilder().add(num)
-      }
+      case JLong(num) =>
+        new CborBuilder().add(num).head
 
-      case JDecimal(num) => firstItem {
-        new CborBuilder().add(num.doubleValue())
-      }
+      case JDecimal(num) =>
+        new CborBuilder().add(num.doubleValue).head
 
-      case JDouble(num) => firstItem {
-        new CborBuilder().add(num)
-      }
+      case JDouble(num) =>
+        new CborBuilder().add(num).head
 
-      case JBool(b) => firstItem {
-        new CborBuilder().add(b)
-      }
+      case JBool(b) =>
+        new CborBuilder().add(b).head
 
-      case JString(s) => firstItem {
-        new CborBuilder().add(s)
-      }
+      case JString(s) =>
+        new CborBuilder().add(s).head
 
       case JArray(arr) => {
         val cborValues = arr.map(jValueToCbor)
@@ -57,6 +53,7 @@ object JValueConversions {
       }
 
       case JNull => Cbor.SimpleValue.NULL
+
       case JNothing => Cbor.SimpleValue.UNDEFINED
     }
 }

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -5,7 +5,6 @@ import co.nstant.in.cbor.{model => Cbor}
 import org.json4s._
 
 object JValueConversions {
-  import scala.language.implicitConversions
   import collection.JavaConverters._
 
   private def firstItem(builder: CborBuilder): Cbor.DataItem =
@@ -13,7 +12,7 @@ object JValueConversions {
     throw new MappingException("Unable to convert JValue to CBOR")
   }
 
-  implicit def jValueToCbor(jValue: JValue): Cbor.DataItem =
+  def jValueToCbor(jValue: JValue): Cbor.DataItem =
     jValue match {
       case JInt(num) => firstItem {
         new CborBuilder().add(num.bigInteger)

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -17,7 +17,8 @@ object JValueConversions {
       case JBool(b) => CBool(b)
       case JString(s) => CString(s)
       case JArray(arr) => CArray(arr.map(jValueToCbor))
-      case JObject(fields) => CMap(fields.map(f => (f._1, jValueToCbor(f._2))))
+      case JObject(fields) =>
+        CMap.withStringKeys(fields.map(f => (f._1, jValueToCbor(f._2))))
     }
   }
 }

--- a/transactor/src/main/scala/io/mediachain/util/cbor/package.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/package.scala
@@ -1,0 +1,69 @@
+package io.mediachain.util
+
+import java.io.ByteArrayOutputStream
+
+import co.nstant.in.cbor.CborEncoder
+
+
+package object cbor {
+  import co.nstant.in.cbor.builder.AbstractBuilder
+  import co.nstant.in.cbor.model.{DataItem, SimpleValue, Array => DataItemArray, Map => DataItemMap}
+
+
+  sealed trait CValue
+  case class CNull() extends CValue
+  case class CUndefined() extends CValue
+  case class CInt(num: BigInt) extends CValue
+  case class CLong(num: Long) extends CValue
+  case class CDouble(num: Double) extends CValue
+  case class CBool(bool: Boolean) extends CValue
+  case class CString(string: String) extends CValue
+  case class CBytes(bytes: Array[Byte]) extends CValue
+  case class CArray(items: List[CValue]) extends CValue
+  case class CMap(fields: List[CField]) extends CValue
+  type CField = (String, CValue)
+
+
+
+  def toDataItem(cValue: CValue): DataItem = cValue match {
+    case _: CNull => SimpleValue.NULL
+    case _: CUndefined => SimpleValue.UNDEFINED
+    case CInt(num) => converter.convert(num)
+    case CLong(num) => converter.convert(num)
+    case CDouble(num) => converter.convert(num)
+    case CBool(bool) => converter.convert(bool)
+    case CString(string) => converter.convert(string)
+    case CBytes(bytes) => converter.convert(bytes)
+    case CArray(items) => {
+      val arrayDataItem = new DataItemArray(items.length)
+      items.foreach(item => arrayDataItem.add(toDataItem(item)))
+      arrayDataItem
+    }
+
+    case CMap(fields) => {
+      val mapDataItem = new DataItemMap(fields.length)
+      fields.foreach(field => mapDataItem.put(
+        toDataItem(CString(field._1)), toDataItem(field._2)
+      ))
+      mapDataItem
+    }
+  }
+
+  def encode(cValue: CValue): Array[Byte] = {
+    val out = new ByteArrayOutputStream
+    new CborEncoder(out).encode(toDataItem(cValue))
+    out.close()
+    out.toByteArray
+  }
+
+  private val converter = new DataItemConverter
+  private class DataItemConverter extends AbstractBuilder[Object](null) {
+    def convert(num: BigInt) = super.convert(num.bigInteger)
+    def convert(num: BigDecimal) = super.convert(num.doubleValue)
+    override def convert(num: Long) = super.convert(num)
+    override def convert(num: Double) = super.convert(num)
+    override def convert(boolean: Boolean) = super.convert(boolean)
+    override def convert(string: String) = super.convert(string)
+    override def convert(bytes: Array[Byte]) = super.convert(bytes)
+  }
+}

--- a/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
+++ b/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
@@ -10,6 +10,7 @@ object CValueGenerators {
 
   val genCNull = Gen.const(CNull())
   val genCUndefined = Gen.const(CUndefined())
+  val genCTag = for (t <- arbitrary[Long]) yield CTag(t)
   val genCInt = for (i <- arbitrary[BigInt]) yield CInt(i)
   val genCDouble = for (d <- arbitrary[Double]) yield CDouble(d)
   val genCBool = for (b <- arbitrary[Boolean]) yield CBool(b)
@@ -18,7 +19,7 @@ object CValueGenerators {
 
 
   val genCPrimitive = Gen.oneOf(
-    genCNull, genCUndefined, genCInt, genCDouble, genCBool, genCBytes, genCString
+    genCNull, genCUndefined, genCTag, genCInt, genCDouble, genCBool, genCBytes, genCString
   )
 
   val genCArray = for {

--- a/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
+++ b/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
@@ -1,0 +1,60 @@
+package io.mediachain.util.cbor
+
+import org.scalacheck._
+import Arbitrary.arbitrary
+import io.mediachain.util.cbor.CborAST._
+import co.nstant.in.cbor.model.{DataItem, RationalNumber, UnsignedInteger, LanguageTaggedString}
+
+object CValueGenerators {
+
+
+  val genCNull = Gen.const(CNull())
+  val genCUndefined = Gen.const(CUndefined())
+  val genCInt = for (i <- arbitrary[BigInt]) yield CInt(i)
+  val genCDouble = for (d <- arbitrary[Double]) yield CDouble(d)
+  val genCBool = for (b <- arbitrary[Boolean]) yield CBool(b)
+  val genCString = for(s <- arbitrary[String]) yield CString(s)
+  val genCBytes = for (b <- arbitrary[Array[Byte]]) yield CBytes(b)
+
+
+  val genCPrimitive = Gen.oneOf(
+    genCNull, genCUndefined, genCInt, genCDouble, genCBool, genCBytes, genCString
+  )
+
+  val genCArray = for {
+    list <- Gen.containerOf[List, CValue](genCPrimitive)
+  } yield CArray(list)
+
+
+  val genCMap = for {
+    keys <- Gen.containerOf[List, CValue](Gen.oneOf(genCInt, genCDouble, genCString))
+    vals <- Gen.containerOfN[List, CValue](keys.length, genCPrimitive)
+    kvs = (keys, vals).zipped.toList
+  } yield CMap(kvs)
+
+
+  // Generate some DataItems we don't unwrap for CUnhandled generator
+  val genRational = for {
+    numerator <- Gen.posNum[Long]
+    denominator <- Gen.posNum[Long]
+  } yield new RationalNumber(
+    new UnsignedInteger(numerator),
+    new UnsignedInteger(denominator)
+  )
+
+  val genTaggedString = for {
+    lang <- Gen.oneOf("en", "fr", "es")
+    str <- Gen.alphaStr
+  } yield new LanguageTaggedString(lang, str)
+
+  val genCUnhandled = for {
+    dataItem <- Gen.oneOf[DataItem](genRational, genTaggedString)
+  } yield CUnhandled(dataItem)
+
+  val genCValue = Gen.oneOf(
+    genCPrimitive, genCArray, genCMap,
+    genCUnhandled
+  )
+
+  implicit def arbitraryCValue: Arbitrary[CValue] = Arbitrary(genCValue)
+}

--- a/transactor/src/test/scala/io/mediachain/util/cbor/CborASTSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/util/cbor/CborASTSpec.scala
@@ -1,0 +1,34 @@
+package io.mediachain.util.cbor
+
+import java.io.ByteArrayOutputStream
+
+import io.mediachain.BaseSpec
+import io.mediachain.util.cbor.CborAST._
+import org.specs2.ScalaCheck
+
+object CborASTSpec extends BaseSpec with ScalaCheck {
+  import io.mediachain.util.cbor.CValueGenerators._
+  import co.nstant.in.cbor.CborEncoder
+
+  def is =
+    s2"""
+         - round-trip encodes to/from cbor-java DataItems $roundTripCborJava
+      """
+
+  def roundTripCborJava = prop { cVal: CValue =>
+    val asDataItem = toDataItem(cVal)
+    val converted = toDataItem(fromDataItem(asDataItem))
+
+
+    // We're comparing the DataItem representation because it will not
+    // fail if the ordering of map keys differs, whereas CMaps will not
+    // be equal if the ordering is different
+    asDataItem must_== converted
+
+    // make sure byte representation is equal
+    val out = new ByteArrayOutputStream
+    new CborEncoder(out).encode(asDataItem)
+    out.close()
+    out.toByteArray must_== CborCodec.encode(cVal)
+  }
+}


### PR DESCRIPTION
Serializes DataObjects and JournalEntries to/from a `CValue` type that wraps the `DataItem`s used by the [cbor-java](https://github.com/c-rack/cbor-java) library.  See #36, which was opened against a different branch.
