### PR TITLE
Copycat cluster test spec

### DIFF
--- a/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/DummyContext.scala
@@ -1,6 +1,7 @@
 package io.mediachain.transactor
 
 import io.atomix.copycat.server.CopycatServer
+import io.atomix.catalyst.transport.Address
 
 case class DummyContext(
   server: CopycatServer, 
@@ -38,5 +39,45 @@ object DummyContext {
     context.client.close()
     context.server.shutdown().join()
     cleanupLogdir(context.logdir)
+  }
+}
+
+case class DummyClusterContext(
+  dummies: Array[DummyContext]
+)
+
+object DummyClusterContext {
+  def setup(address1: String, address2: String, address3: String,
+            blocksize: Int = StateMachine.JournalBlockSize) = {
+    println("*** SETUP DUMMY COPYCAT CLUSTER")
+    val store1 = new Dummies.DummyStore
+    val logdir1 = DummyContext.setupLogdir()
+    val server1 = Copycat.Server.build(address1, logdir1, store1, blocksize)
+    server1.bootstrap().join()
+    val store2 = new Dummies.DummyStore
+    val logdir2 = DummyContext.setupLogdir()
+    val server2 = Copycat.Server.build(address2, logdir2, store2, blocksize)
+    server2.join(new Address(address1)).join()
+    val store3 = new Dummies.DummyStore
+    val logdir3 = DummyContext.setupLogdir()
+    val server3 = Copycat.Server.build(address3, logdir3, store3, blocksize)
+    server3.join(new Address(address1), new Address(address2)).join()
+    val client1 = Copycat.Client.build()
+    client1.connect(address1)
+    val client2 = Copycat.Client.build()
+    client2.connect(address2)
+    val client3 = Copycat.Client.build()
+    client3.connect(address3)
+    DummyClusterContext(Array(DummyContext(server1, client1, store1, logdir1),
+                              DummyContext(server2, client2, store2, logdir2),
+                              DummyContext(server3, client3, store3, logdir3)))
+  }
+  
+  def shutdown(context: DummyClusterContext) {
+    println("*** SHUTDOWN DUMMY COPYCAT CLUSTER")
+    // close all clients before shutting down any servers
+    context.dummies.foreach(_.client.close())
+    context.dummies.foreach(_.server.shutdown().join())
+    context.dummies.foreach(dummy => DummyContext.cleanupLogdir(dummy.logdir))
   }
 }

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalBlockchainSpec2.scala
@@ -30,7 +30,7 @@ object JournalBlockchainSpec2 extends io.mediachain.BaseSpec
     JournalBlockchainSpec2Context.shutdown()
   }
   
-  def generateBlock = {
+  def generateBlock = skipped {
     val context = JournalBlockchainSpec2Context.context
     val op = context.dummy.client.insert(Entity(Map()))
     val res = Await.result(op, timeout)

--- a/transactor/src/test/scala/io/mediachain/transactor/JournalClusterSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/JournalClusterSpec.scala
@@ -1,0 +1,172 @@
+package io.mediachain.transactor
+
+import org.specs2.specification.{AfterAll, BeforeAll}
+
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+import scala.concurrent.{Future, Await}
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+import cats.data.Xor
+
+import Types._
+
+object JournalClusterSpec extends io.mediachain.BaseSpec
+  with BeforeAll
+  with AfterAll
+{
+  val timeout = Duration(10, TimeUnit.SECONDS)
+
+  def is =
+    sequential ^
+  s2"""
+  JournalStateMachine is consistent in a cluster:
+   - the cluster can insert and update the journal $insertAndUpdateJournal
+   - all clients see the same chain mappings $checkChainViews
+   - all clients see the same current block $checkCurrentBlockViews
+   - all clients received the same journal commit events $checkCommitEvents
+   - the cluster can generate some blocks $generateBlocks
+   - all clients received the same journal block events $checkBlockEvents
+  """
+
+  def beforeAll() {
+    JournalClusterSpecContext.setup()
+  }
+  
+  def afterAll() {
+    JournalClusterSpecContext.shutdown()
+  }
+  
+  def insertAndUpdateJournal = {
+    val context = JournalClusterSpecContext.context
+    val ops = context.cluster.dummies.map(insertAndUpdate(_))
+    val res = ops.map(Await.result(_, timeout))
+    context.refs = res.map {
+      case Xor.Left(_) => null
+      case Xor.Right(tuple) => tuple
+    }
+    
+    (res(0) must beRightXor) and
+    (res(1) must beRightXor) and
+    (res(2) must beRightXor)
+  }
+  
+  private def insertAndUpdate(dummy: DummyContext)
+  : Future[Xor[JournalError, (Reference, Reference)]] = {
+    dummy.client.insert(Entity(Map()))
+      .flatMap { 
+        case err: Xor.Left[JournalError] => Future { err }
+        case Xor.Right(entry1) => {
+          dummy.client.update(entry1.ref, EntityChainCell(entry1.ref, None, Map()))
+            .map {
+              case err: Xor.Left[JournalError] => err
+              case Xor.Right(entry2) => Xor.Right((entry1.ref, entry2.chain))
+          }
+        }
+      }
+  }
+  
+  def checkChainViews = {
+    val context = JournalClusterSpecContext.context
+    val views = context.refs.map { 
+      case (ref, chainRef) => 
+        context.cluster.dummies.map { dummy =>
+          val op = dummy.client.lookup(ref)
+          Await.result(op, timeout)
+        }
+    }
+    val expected = context.refs.map {
+      case (_, chainRef) => context.cluster.dummies.map {_ => Some(chainRef)}
+    }
+    views must_== expected
+  }
+  
+  def checkCurrentBlockViews = {
+    val context = JournalClusterSpecContext.context
+    val blocks = context.cluster.dummies.map { dummy =>
+      val op = dummy.client.currentBlock
+      Await.result(op, timeout)
+    }
+    (blocks(0).index must_== 6) and 
+    (blocks(0).entries.toList must_== blocks(1).entries.toList) and
+    (blocks(0).entries.toList must_== blocks(2).entries.toList)
+  }
+  
+  def checkCommitEvents = {
+    val context = JournalClusterSpecContext.context
+    val commits = context.commits.map(collectQueue(_))
+    (commits(0).length must_== 6) and
+    (commits(0) must_== commits(1)) and
+    (commits(0) must_== commits(2))
+  }
+  
+  private def collectQueue[T](queue: BlockingQueue[T]) = {
+    def loop(tail: List[T]): List[T] = {
+      val next = queue.poll(1, TimeUnit.SECONDS)
+      if (next != null) {
+        loop(next :: tail)
+      } else tail.reverse
+    }
+    loop(List())
+  }
+  
+  def generateBlocks = {
+    val context = JournalClusterSpecContext.context
+    val ops = context.cluster.dummies.zipWithIndex.map { 
+      case (dummy, index) =>
+        for { 
+          _ <- 3 to JournalClusterSpecContext.BlockSize
+          ref = context.refs(index)._1
+        } yield dummy.client.update(ref, EntityChainCell(ref, None, Map()))
+    }
+    ops.foreach { opseq => opseq.foreach(Await.result(_, timeout)) }
+    ok
+  }
+  
+  def checkBlockEvents = {
+    val context = JournalClusterSpecContext.context
+    val blocks = context.blocks.map(collectQueue(_))
+    (blocks(0).length must_== 3) and
+    (blocks(0) must_== blocks(1)) and
+    (blocks(0) must_== blocks(2))
+  }
+}
+
+class JournalClusterSpecContext(val cluster: DummyClusterContext,
+                                val commits: Array[BlockingQueue[JournalEntry]],
+                                val blocks: Array[BlockingQueue[Reference]]) {
+  var refs: Array[(Reference, Reference)] = null
+}
+
+object JournalClusterSpecContext {
+  val BlockSize = 20
+  var instance: JournalClusterSpecContext = null
+  
+  def setup(): Unit = {
+    val cluster = DummyClusterContext.setup("127.0.0.1:10004", 
+                                            "127.0.0.1:10005", 
+                                            "127.0.0.1:10006",
+                                            BlockSize)
+    val queues  = cluster.dummies.map { dummy =>
+      val commits: BlockingQueue[JournalEntry] = new LinkedBlockingQueue[JournalEntry]
+      val blocks: BlockingQueue[Reference] = new LinkedBlockingQueue[Reference]
+      dummy.client.listen(new JournalListener {
+        def onJournalCommit(entry: JournalEntry) {
+          commits.offer(entry)
+        }
+        def onJournalBlock(ref: Reference) {
+          blocks.offer(ref)
+        }
+      })
+      (commits, blocks)
+    }
+    val commits = queues.map(_._1)
+    val blocks = queues.map(_._2)
+    instance = new JournalClusterSpecContext(cluster, commits, blocks)
+  }
+  
+  def shutdown(): Unit = {
+    DummyClusterContext.shutdown(instance.cluster)
+  }
+  
+  def context = instance
+}


### PR DESCRIPTION
Adds a test spec for a cluster of copycat servers and disables JournalBlockchainSpec2.

The new test creates a cluster with 3 servers and tests with 3 clients each connected to a different server.
