### PR TITLE
cbor deserialization refactor

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,8 +25,15 @@ object MediachainBuild extends Build {
     scalacOptions in Test ++= Seq("-Yrangepos")
   )
 
+  // TODO: replace this with maven-published version
+  val scalaMultihashCommit = "c21efd1b3534d9a4c5f7b2bc2d971eed0e5a2744"
+  lazy val scalaMultihash = RootProject(uri(
+    s"git://github.com/mediachain/scala-multihash.git#$scalaMultihashCommit"
+  ))
+
   lazy val transactor = Project("transactor", file("transactor"))
     .settings(settings)
+    .dependsOn(scalaMultihash)
 
   lazy val peer = Project("peer", file("peer"))
     .settings(settings)

--- a/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
@@ -132,7 +132,7 @@ object CborSerialization {
   // TODO: create multiple deserializer maps for different contexts
   // e.g. DataStore should deserialize chain cells to specific subtypes, etc
   val transactorDeserializers: DeserializerMap =
-    Seq(
+    Map(
       CBORTypeNames.Entity -> EntityDeserializer,
       CBORTypeNames.Artefact -> ArtefactDeserializer,
       CBORTypeNames.EntityChainCell -> EntityChainCellDeserializer,
@@ -140,7 +140,7 @@ object CborSerialization {
       CBORTypeNames.CanonicalEntry -> CanonicalEntryDeserializer,
       CBORTypeNames.ChainEntry -> ChainEntryDeserializer,
       CBORTypeNames.JournalBlock -> JournalBlockDeserializer
-    ).map(t => (t._1, t._2.asInstanceOf[CborDeserializer[CborSerializable]])).toMap
+    )
 
   val defaultDeserializers = transactorDeserializers
 
@@ -173,7 +173,7 @@ object CborSerialization {
     * a cbor `CValue`.
     * @tparam T the type of object to decode. Must be `CborSerializable`.
     */
-  trait CborDeserializer[T <: CborSerializable] {
+  trait CborDeserializer[+T <: CborSerializable] {
     def fromCMap(cMap: CMap): Xor[DeserializationError, T]
 
     def fromCValue(cValue: CValue): Xor[DeserializationError, T] =

--- a/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
@@ -389,15 +389,16 @@ object CborSerialization {
     *        `typeNames` set
     */
   def assertOneOfRequiredTypeNames(cMap: CMap, typeNames: Set[CborTypeName])
-  : Xor[DeserializationError, Unit] = {
-    if (getTypeName(cMap).exists(n => typeNames.contains(n))) {
-      Xor.right({})
-    } else {
-      getTypeName(cMap)
-        .flatMap(typeName =>
-          Xor.left(UnexpectedObjectType(typeName.toString)))
-    }
-  }
+  : Xor[DeserializationError, Unit] =
+    for {
+      typeName <- getTypeName(cMap)
+      _ <- if (typeNames.contains(typeName)) {
+        Xor.right({})
+      } else {
+        Xor.left(UnexpectedObjectType(typeName.toString))
+      }
+    } yield {}
+
 
   /**
     * Get the value of the `type` field from the given cbor map

--- a/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
@@ -1,113 +1,29 @@
 package io.mediachain.transactor
 
-import io.mediachain.transactor.Dummies.{DummyReference, DummyReferenceDeserializer}
-
-import scala.util.Try
 
 
 
-object TypeSerialization {
+
+object CborSerialization {
 
   import cats.data.Xor
+  import io.mediachain.transactor.Dummies.DummyReference
   import io.mediachain.transactor.Types._
   import io.mediachain.util.cbor.CborAST._
   import io.mediachain.util.cbor.CborCodec
 
-  object CBORTypeNames {
-    val Entity = "entity"
-    val Artefact = "artefact"
-    val EntityChainCell = "entityChainCell"
-    val ArtefactChainCell = "artefactChainCell"
-    val CanonicalEntry = "insert"
-    val ChainEntry = "update"
-    val JournalBlock = "journalBlock"
-
-    // TODO: Include subtypes
-    val ArtefactChainCellTypes: Set[String] = Set(
-      ArtefactChainCell
-    )
-
-    val EntityChainCellTypes: Set[String] = Set(
-      EntityChainCell
-    )
-  }
-
-
-  trait CborDeserializer[T] {
-    def fromCMap(cMap: CMap): Xor[DeserializationError, T]
-
-    def fromCValue(cValue: CValue): Xor[DeserializationError, T] =
-      cValue match {
-        case (cMap: CMap) => fromCMap(cMap)
-        case _ => Xor.left(UnexpectedCborType(
-          s"Expected CBOR map, but received ${cValue.getClass.getName}"
-        ))
-      }
-  }
-
-
-  sealed trait DeserializationError
-
-  case class CborDecodingFailed() extends DeserializationError
-
-  case class UnexpectedCborType(message: String) extends DeserializationError
-
-  case class ReferenceDecodingFailed(message: String) extends DeserializationError
-
-  case class TypeNameNotFound() extends DeserializationError
-
-  case class UnknownObjectType(typeName: String) extends DeserializationError
-
-  case class RequiredFieldNotFound(fieldName: String) extends DeserializationError
-
-  def dataObjectFromCbor(cValue: CValue): Xor[DeserializationError, DataObject] =
-    fromCbor(cValue) match {
-      case Xor.Left(err) => Xor.left(err)
+  import scala.util.Try
       case Xor.Right(dataObject: DataObject) => Xor.right(dataObject)
       case Xor.Right(unknownObject) =>
         Xor.left(UnexpectedCborType(
           s"Expected DataObject, but got ${unknownObject.getClass.getTypeName}"
-        ))
-    }
-
-  def journalEntryFromCbor(cValue: CValue): Xor[DeserializationError, JournalEntry] =
-    fromCbor(cValue) match {
-      case Xor.Left(err) => Xor.left(err)
       case Xor.Right(journalEntry: JournalEntry) => Xor.right(journalEntry)
       case Xor.Right(unknownObject) =>
         Xor.left(UnexpectedCborType(
           s"Expected JournalEntry, but got ${unknownObject.getClass.getTypeName}"
-        ))
-    }
-
-  def fromCborBytes(bytes: Array[Byte]): Xor[DeserializationError, CborSerializable] =
-    CborCodec.decode(bytes) match {
-      case (_: CTag) :: (taggedValue: CValue) :: _ => fromCbor(taggedValue)
       case (cValue: CValue) :: _ => fromCbor(cValue)
-      case Nil => Xor.left(CborDecodingFailed())
-    }
-
-  def fromCbor(cValue: CValue): Xor[DeserializationError, CborSerializable] =
-    cValue match {
-      case (cMap: CMap) => fromCMap(cMap)
       case _ => Xor.left(UnexpectedCborType(
         s"Expected CBOR map, but received ${cValue.getClass.getName}"
-      ))
-    }
-
-  def fromCMap(cMap: CMap): Xor[DeserializationError, CborSerializable] = {
-    val typeNameOpt: Option[String] =
-      cMap.getAs[CString]("type").map(_.string)
-
-    Xor.fromOption(typeNameOpt, TypeNameNotFound())
-      .flatMap(name => fromCMap(cMap, name))
-  }
-
-
-  def fromCMap(cMap: CMap, typeName: String)
-  : Xor[DeserializationError, CborSerializable] = {
-
-    // TODO: create multiple deserializer maps for different contexts
     // e.g. DataStore should deserialize chain cells to specific subtypes, etc
     val transactorDeserializers
     : Map[String, CborDeserializer[CborSerializable]] = Map(
@@ -131,21 +47,9 @@ object TypeSerialization {
 
       CBORTypeNames.JournalBlock -> JournalBlockDeserializer
         .asInstanceOf[CborDeserializer[CborSerializable]]
-    )
-
-    for {
-      deserializer <- Xor.fromOption(
-        transactorDeserializers.get(typeName),
-        UnknownObjectType(typeName)
       )
       value <- deserializer.fromCMap(cMap)
     } yield value
-  }
-
-
-  object EntityDeserializer extends CborDeserializer[Entity]
-  {
-    def fromCMap(cMap: CMap): Xor[DeserializationError, Entity] =
       assertRequiredTypeName(cMap, CBORTypeNames.Entity).map { _ =>
         Entity(cMap.asStringKeyedMap)
       }
@@ -274,58 +178,19 @@ object TypeSerialization {
         seqno <- Xor.catchNonFatal {
           linkString.substring("dummy@".length).toInt
         }.leftMap(_ => ReferenceDecodingFailed(s"Unable to parse int from $linkString"))
-      } yield new DummyReference(seqno)
-  }
-
-  def assertRequiredTypeName(cMap: CMap, typeName: String)
-  : Xor[DeserializationError, Unit] = {
-    getTypeName(cMap)
       .flatMap { name =>
         if (name == typeName) {
           Xor.right({})
         } else {
           Xor.left(UnknownObjectType(name))
         }
-      }
-  }
-
-  def assertOneOfRequiredTypeNames(cMap: CMap, typeNames: Set[String])
-  : Xor[DeserializationError, Unit] = {
-    getTypeName(cMap)
       .flatMap { name =>
         if (typeNames.contains(name)) {
           Xor.right({})
         } else {
           Xor.left(UnknownObjectType(name))
         }
-      }
-  }
-
-  def getTypeName(cMap: CMap): Xor[TypeNameNotFound, String] =
-    getRequired[CString](cMap, "type")
-      .map(_.string)
-      .leftMap(_ => TypeNameNotFound())
-
-
-  def getRequired[T <: CValue](cMap: CMap, fieldName: String)
-  : Xor[RequiredFieldNotFound, T] = Xor.fromOption(
-    cMap.getAs[T](fieldName),
     RequiredFieldNotFound(fieldName)
-  )
-
-
-  def getRequiredReference(cMap: CMap, fieldName: String)
-  : Xor[DeserializationError, Reference] =
-    getRequired[CMap](cMap, fieldName)
-    .flatMap(referenceFromCMap)
-
-
-  def getOptionalReference(cMap: CMap, fieldName: String): Option[Reference] =
-    cMap.getAs[CMap](fieldName)
-      .flatMap(referenceFromCMap(_).toOption)
-
-
-  def referenceFromCMap(cMap: CMap): Xor[DeserializationError, Reference] =
     getRequired[CMap](cMap, "@link")
       .flatMap { linkVal: CValue =>
         linkVal match {

--- a/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
@@ -392,12 +392,12 @@ object CborSerialization {
   : Xor[DeserializationError, Unit] =
     for {
       typeName <- getTypeName(cMap)
-      _ <- if (typeNames.contains(typeName)) {
+      result <- if (typeNames.contains(typeName)) {
         Xor.right({})
       } else {
         Xor.left(UnexpectedObjectType(typeName.toString))
       }
-    } yield {}
+    } yield result
 
 
   /**

--- a/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
@@ -76,33 +76,6 @@ object CborSerialization {
     */
   def fromCMap(cMap: CMap)
   : Xor[DeserializationError, CborSerializable] = {
-
-    // TODO: create multiple deserializer maps for different contexts
-    // e.g. DataStore should deserialize chain cells to specific subtypes, etc
-    val transactorDeserializers
-    : Map[String, CborDeserializer[CborSerializable]] = Map(
-      CBORTypeNames.Entity -> EntityDeserializer
-        .asInstanceOf[CborDeserializer[CborSerializable]],
-
-      CBORTypeNames.Artefact -> ArtefactDeserializer
-        .asInstanceOf[CborDeserializer[CborSerializable]],
-
-      CBORTypeNames.EntityChainCell -> EntityChainCellDeserializer
-        .asInstanceOf[CborDeserializer[CborSerializable]],
-
-      CBORTypeNames.ArtefactChainCell -> ArtefactChainCellDeserializer
-        .asInstanceOf[CborDeserializer[CborSerializable]],
-
-      CBORTypeNames.CanonicalEntry -> CanonicalEntryDeserializer
-        .asInstanceOf[CborDeserializer[CborSerializable]],
-
-      CBORTypeNames.ChainEntry -> ChainEntryDeserializer
-        .asInstanceOf[CborDeserializer[CborSerializable]],
-
-      CBORTypeNames.JournalBlock -> JournalBlockDeserializer
-        .asInstanceOf[CborDeserializer[CborSerializable]]
-    )
-
     for {
       typeName <- getTypeName(cMap)
       deserializer <- Xor.fromOption(
@@ -143,6 +116,20 @@ object CborSerialization {
       EntityChainCell
     )
   }
+
+
+  // TODO: create multiple deserializer maps for different contexts
+  // e.g. DataStore should deserialize chain cells to specific subtypes, etc
+  val transactorDeserializers: Map[String, CborDeserializer[CborSerializable]] =
+    Seq(
+      CBORTypeNames.Entity -> EntityDeserializer,
+      CBORTypeNames.Artefact -> ArtefactDeserializer,
+      CBORTypeNames.EntityChainCell -> EntityChainCellDeserializer,
+      CBORTypeNames.ArtefactChainCell -> ArtefactChainCellDeserializer,
+      CBORTypeNames.CanonicalEntry -> CanonicalEntryDeserializer,
+      CBORTypeNames.ChainEntry -> ChainEntryDeserializer,
+      CBORTypeNames.JournalBlock -> JournalBlockDeserializer
+    ).map(t => (t._1, t._2.asInstanceOf[CborDeserializer[CborSerializable]])).toMap
 
 
   /**

--- a/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
@@ -13,17 +13,71 @@ object CborSerialization {
   import io.mediachain.util.cbor.CborCodec
 
   import scala.util.Try
+
+  /**
+    * Try to deserialize a `DataObject` from a cbor `CValue`
+    * @param cValue the `CValue` to decode
+    * @return a `DataObject`, or `DeserializationError` on failure
+    */
+  def dataObjectFromCbor(cValue: CValue): Xor[DeserializationError, DataObject] =
+    fromCbor(cValue) match {
+      case Xor.Left(err) => Xor.left(err)
       case Xor.Right(dataObject: DataObject) => Xor.right(dataObject)
       case Xor.Right(unknownObject) =>
         Xor.left(UnexpectedCborType(
           s"Expected DataObject, but got ${unknownObject.getClass.getTypeName}"
+        ))
+    }
+
+  /**
+    * Try to deserialize a `JournalEntry` from a cbor `CValue`
+    * @param cValue the `CValue` to decode
+    * @return a `JournalEntry`, or DeserializationError on failure
+    */
+  def journalEntryFromCbor(cValue: CValue): Xor[DeserializationError, JournalEntry] =
+    fromCbor(cValue) match {
+      case Xor.Left(err) => Xor.left(err)
       case Xor.Right(journalEntry: JournalEntry) => Xor.right(journalEntry)
       case Xor.Right(unknownObject) =>
         Xor.left(UnexpectedCborType(
           s"Expected JournalEntry, but got ${unknownObject.getClass.getTypeName}"
+        ))
+    }
+
+  /**
+    * Try to deserialize some `CborSerializable` object from a byte array.
+    * @param bytes an array of (presumably) cbor-encoded data
+    * @return a `CborSerializable` object, or a `DeserializationError` on failure
+    */
+  def fromCborBytes(bytes: Array[Byte]): Xor[DeserializationError, CborSerializable] =
+    CborCodec.decode(bytes) match {
+      case (_: CTag) :: (taggedValue: CValue) :: _ => fromCbor(taggedValue)
       case (cValue: CValue) :: _ => fromCbor(cValue)
+      case Nil => Xor.left(CborDecodingFailed())
+    }
+
+  /**
+    * Try to deserialize a `CborSerializable` object from a cbor `CValue`
+    * @param cValue the `CValue` to decode
+    * @return a `CborSerializable` object, or a `DeserializationError` on failure
+    */
+  def fromCbor(cValue: CValue): Xor[DeserializationError, CborSerializable] =
+    cValue match {
+      case (cMap: CMap) => fromCMap(cMap)
       case _ => Xor.left(UnexpectedCborType(
         s"Expected CBOR map, but received ${cValue.getClass.getName}"
+      ))
+    }
+
+  /**
+    * Try to deserialize some `CborSerializable` object from a cbor `CMap`.
+    * @param cMap a cbor map representing the object to decode
+    * @return a `CborSerializable` object, or a `DeserializationError` on failure
+    */
+  def fromCMap(cMap: CMap)
+  : Xor[DeserializationError, CborSerializable] = {
+
+    // TODO: create multiple deserializer maps for different contexts
     // e.g. DataStore should deserialize chain cells to specific subtypes, etc
     val transactorDeserializers
     : Map[String, CborDeserializer[CborSerializable]] = Map(
@@ -47,9 +101,113 @@ object CborSerialization {
 
       CBORTypeNames.JournalBlock -> JournalBlockDeserializer
         .asInstanceOf[CborDeserializer[CborSerializable]]
+    )
+
+    for {
+      typeName <- getTypeName(cMap)
+      deserializer <- Xor.fromOption(
+        transactorDeserializers.get(typeName),
+        UnknownObjectType(typeName)
       )
       value <- deserializer.fromCMap(cMap)
     } yield value
+  }
+
+
+  /**
+    * String constants for the `type` field used to indicate the type of
+    * object represented by a cbor map.
+    */
+  object CBORTypeNames {
+    val Entity = "entity"
+    val Artefact = "artefact"
+    val EntityChainCell = "entityChainCell"
+    val ArtefactChainCell = "artefactChainCell"
+    val CanonicalEntry = "insert"
+    val ChainEntry = "update"
+    val JournalBlock = "journalBlock"
+
+
+    // TODO: Include subtypes in the sets below
+    /**
+      * The set of all valid ArtefactChainCell type names (including subtypes)
+      */
+    val ArtefactChainCellTypes: Set[String] = Set(
+      ArtefactChainCell
+    )
+
+    /**
+      * The set of all valid EntityChainCell type names (including subtypes)
+      */
+    val EntityChainCellTypes: Set[String] = Set(
+      EntityChainCell
+    )
+  }
+
+
+  /**
+    * Trait for objects that can be serialized to cbor.
+    */
+  trait CborSerializable {
+    val CBORType: String
+
+    def toCborBytes: Array[Byte] = CborCodec.encode(toCbor)
+
+    def toCbor: CValue =
+      toCMapWithDefaults(Map.empty, Map.empty)
+
+    def toCMapWithDefaults(defaults: Map[String, CValue],
+      optionals: Map[String, Option[CValue]])
+    : CMap = {
+      val merged = defaults ++ optionals.flatMap {
+        case (_, None) => List.empty
+        case (k, Some(v)) => List(k -> v)
+      }
+      val withType = ("type", CString(CBORType)) :: merged.toList
+
+      CMap.withStringKeys(withType)
+    }
+  }
+
+  /**
+    * Trait for an object that can deserialize a value of type `T` from
+    * a cbor `CValue`.
+    * @tparam T the type of object to decode. Must be `CborSerializable`.
+    */
+  trait CborDeserializer[T <: CborSerializable] {
+    def fromCMap(cMap: CMap): Xor[DeserializationError, T]
+
+    def fromCValue(cValue: CValue): Xor[DeserializationError, T] =
+      cValue match {
+        case (cMap: CMap) => fromCMap(cMap)
+        case _ => Xor.left(UnexpectedCborType(
+          s"Expected CBOR map, but received ${cValue.getClass.getName}"
+        ))
+      }
+  }
+
+
+  /**
+    * Indicates that deserialization from cbor failed
+    */
+  sealed trait DeserializationError
+
+  case class CborDecodingFailed() extends DeserializationError
+
+  case class UnexpectedCborType(message: String) extends DeserializationError
+
+  case class ReferenceDecodingFailed(message: String) extends DeserializationError
+
+  case class TypeNameNotFound() extends DeserializationError
+
+  case class UnknownObjectType(typeName: String) extends DeserializationError
+
+  case class RequiredFieldNotFound(fieldName: String) extends DeserializationError
+
+
+  object EntityDeserializer extends CborDeserializer[Entity]
+  {
+    def fromCMap(cMap: CMap): Xor[DeserializationError, Entity] =
       assertRequiredTypeName(cMap, CBORTypeNames.Entity).map { _ =>
         Entity(cMap.asStringKeyedMap)
       }
@@ -178,19 +336,108 @@ object CborSerialization {
         seqno <- Xor.catchNonFatal {
           linkString.substring("dummy@".length).toInt
         }.leftMap(_ => ReferenceDecodingFailed(s"Unable to parse int from $linkString"))
+      } yield new DummyReference(seqno)
+  }
+
+
+  /**
+    * Assert that the cbor map contains a `type` field with the given value.
+    * @param cMap a cbor `CMap` to check the type of
+    * @param typeName the required value of the `type` field
+    * @return `Unit` on success, or `DeserializationError` if there is no
+    *        `type` field, or if the value is incorrect
+    */
+  def assertRequiredTypeName(cMap: CMap, typeName: String)
+  : Xor[DeserializationError, Unit] = {
+    getTypeName(cMap)
       .flatMap { name =>
         if (name == typeName) {
           Xor.right({})
         } else {
           Xor.left(UnknownObjectType(name))
         }
+      }
+  }
+
+  /**
+    * Assert that the cbor map contains a `type` field whose value is one of
+    * the members of the `typeNames` set.
+    * @param cMap a cbor `CMap` to check the type of
+    * @param typeNames a set of valid values for the `type` field
+    * @return `Unit` on success, or `DeserializationError` if there is no
+    *        `type` field, or if the value is not contained in the
+    *        `typeNames` set
+    */
+  def assertOneOfRequiredTypeNames(cMap: CMap, typeNames: Set[String])
+  : Xor[DeserializationError, Unit] = {
+    getTypeName(cMap)
       .flatMap { name =>
         if (typeNames.contains(name)) {
           Xor.right({})
         } else {
           Xor.left(UnknownObjectType(name))
         }
+      }
+  }
+
+  /**
+    * Get the value of the `type` field from the given cbor map
+    * @param cMap a cbor `CMap` to get the type name from
+    * @return the value of the `type` field, or a `TypeNameNotFound` error if
+    *         no `type` field exists
+    */
+  def getTypeName(cMap: CMap): Xor[TypeNameNotFound, String] =
+    getRequired[CString](cMap, "type")
+      .map(_.string)
+      .leftMap(_ => TypeNameNotFound())
+
+
+  /**
+    * Get the value of a required field in a cbor map.
+    * @param cMap a cbor `CMap` to pull the field from
+    * @param fieldName the name of the field
+    * @tparam T the type of `CValue` to return
+    * @return the value of the field, or a `RequiredFieldNotFound` error if
+    *         the field doesn't exist
+    */
+  def getRequired[T <: CValue](cMap: CMap, fieldName: String)
+  : Xor[RequiredFieldNotFound, T] = Xor.fromOption(
+    cMap.getAs[T](fieldName),
     RequiredFieldNotFound(fieldName)
+  )
+
+
+  /**
+    * Get a required field whose value is an encoded `Reference` type.
+    * @param cMap a cbor `CMap` to pull the reference field from
+    * @param fieldName the name of the field
+    * @return the deserialized `Reference`, or a `DeserializationError` if
+    *         the field doesn't exist or can't be decoded as a reference
+    */
+  def getRequiredReference(cMap: CMap, fieldName: String)
+  : Xor[DeserializationError, Reference] =
+    getRequired[CMap](cMap, fieldName)
+    .flatMap(referenceFromCMap)
+
+  /**
+    * Get an optional `Reference` value from the cbor map.
+    * @param cMap a cbor `CMap` to pull the reference field from.
+    * @param fieldName the name of the field
+    * @return Some[Reference] if the field exists and can be decoded,
+    *         None otherwise
+    */
+  def getOptionalReference(cMap: CMap, fieldName: String): Option[Reference] =
+    cMap.getAs[CMap](fieldName)
+      .flatMap(referenceFromCMap(_).toOption)
+
+
+  /**
+    * Try to decode a `Reference` from a cbor map
+    * @param cMap the cbor `CMap` to decode as a `Reference`
+    * @return the decoded `Reference`, or a `DeserializationError` if decoding
+    *         fails
+    */
+  def referenceFromCMap(cMap: CMap): Xor[DeserializationError, Reference] =
     getRequired[CMap](cMap, "@link")
       .flatMap { linkVal: CValue =>
         linkVal match {

--- a/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CborSerialization.scala
@@ -18,7 +18,7 @@ object CborSerialization {
 
   /**
     * Try to deserialize a `DataObject` from a cbor `CValue`
- *
+    *
     * @param cValue the `CValue` to decode
     * @return a `DataObject`, or `DeserializationError` on failure
     */
@@ -36,6 +36,7 @@ object CborSerialization {
 
   /**
     * Try to deserialize a `JournalEntry` from a cbor `CValue`
+    *
     * @param cValue the `CValue` to decode
     * @return a `JournalEntry`, or DeserializationError on failure
     */
@@ -53,6 +54,7 @@ object CborSerialization {
 
   /**
     * Try to deserialize some `CborSerializable` object from a byte array.
+    *
     * @param bytes an array of (presumably) cbor-encoded data
     * @return a `CborSerializable` object, or a `DeserializationError` on failure
     */
@@ -67,6 +69,7 @@ object CborSerialization {
 
   /**
     * Try to deserialize a `CborSerializable` object from a cbor `CValue`
+    *
     * @param cValue the `CValue` to decode
     * @return a `CborSerializable` object, or a `DeserializationError` on failure
     */
@@ -82,6 +85,7 @@ object CborSerialization {
 
   /**
     * Try to deserialize some `CborSerializable` object from a cbor `CMap`.
+    *
     * @param cMap a cbor map representing the object to decode
     * @return a `CborSerializable` object, or a `DeserializationError` on failure
     */
@@ -194,6 +198,7 @@ object CborSerialization {
   /**
     * Trait for an object that can deserialize a value of type `T` from
     * a cbor `CValue`.
+    *
     * @tparam T the type of object to decode. Must be `CborSerializable`.
     */
   trait CborDeserializer[+T <: CborSerializable] {
@@ -362,7 +367,7 @@ object CborSerialization {
 
   /**
     * Assert that the cbor map contains a `type` field with the given value.
- *
+    *
     * @param cMap a cbor `CMap` to check the type of
     * @param typeName the required value of the `type` field
     * @return `Unit` on success, or `DeserializationError` if there is no
@@ -402,7 +407,7 @@ object CborSerialization {
 
   /**
     * Get the value of the `type` field from the given cbor map
- *
+    *
     * @param cMap a cbor `CMap` to get the type name from
     * @return the value of the `type` field, or a `DeserializationError` error if
     *         no `type` field exists, or its value is not a valid type name
@@ -415,7 +420,7 @@ object CborSerialization {
 
   /**
     * Get the value of a required field in a cbor map.
- *
+    * 
     * @param cMap a cbor `CMap` to pull the field from
     * @param fieldName the name of the field
     * @tparam T the type of `CValue` to return
@@ -431,7 +436,7 @@ object CborSerialization {
 
   /**
     * Get a required field whose value is an encoded `Reference` type.
- *
+    *
     * @param cMap a cbor `CMap` to pull the reference field from
     * @param fieldName the name of the field
     * @return the deserialized `Reference`, or a `DeserializationError` if
@@ -443,8 +448,8 @@ object CborSerialization {
     .flatMap(referenceFromCMap)
 
   /**
-    * Get an optional `Reference` value from the cbor map.
- *
+    * Get an optional `Reference` value from the cbor map
+    *
     * @param cMap a cbor `CMap` to pull the reference field from.
     * @param fieldName the name of the field
     * @return Some[Reference] if the field exists and can be decoded,

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -18,7 +18,7 @@ object Dummies {
     // but having the base Reference type implement CborSerializable
     // greatly simplifies the serialization logic for objects that contain
     // references.
-    val CBORType = None
+    val mediachainType = None
     override def toCbor = CMap.withStringKeys("@dummy-link" -> CInt(num))
   }
 

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -1,6 +1,6 @@
 package io.mediachain.transactor
 
-import scala.collection.mutable.{Map => MMap, HashMap => MHashMap}
+import scala.collection.mutable.{HashMap => MHashMap, Map => MMap}
 
 object Dummies {
   import io.mediachain.transactor.Types._
@@ -14,7 +14,7 @@ object Dummies {
     override def hashCode = num
     override def toString = "dummy@" + num
 
-    val CBORType = "" // unused
+    val CBORType = None
     override def toCbor = CMap.withStringKeys("@link" -> CString(this.toString))
   }
 

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable.{Map => MMap, HashMap => MHashMap}
 object Dummies {
   import io.mediachain.transactor.Types._
   import io.mediachain.util.cbor.CborAST._
-  
+
   class DummyReference(val num: Int) extends Reference {
     override def equals(that: Any) = {
       that.isInstanceOf[DummyReference] && 
@@ -17,7 +17,7 @@ object Dummies {
     val CBORType = "" // unused
     override def toCbor = CMap.withStringKeys("@link" -> CString(this.toString))
   }
-  
+
   class DummyStore extends Datastore {
     var seqno = 0
     val store: MMap[Reference, DataObject] = new MHashMap

--- a/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Dummies.scala
@@ -14,8 +14,12 @@ object Dummies {
     override def hashCode = num
     override def toString = "dummy@" + num
 
+    // CBOR serialization is not used for dummy references,
+    // but having the base Reference type implement CborSerializable
+    // greatly simplifies the serialization logic for objects that contain
+    // references.
     val CBORType = None
-    override def toCbor = CMap.withStringKeys("@link" -> CString(this.toString))
+    override def toCbor = CMap.withStringKeys("@dummy-link" -> CInt(num))
   }
 
   class DummyStore extends Datastore {

--- a/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/TypeSerialization.scala
@@ -82,6 +82,7 @@ object TypeSerialization {
 
   def fromCborBytes(bytes: Array[Byte]): Xor[DeserializationError, CborSerializable] =
     CborCodec.decode(bytes) match {
+      case (_: CTag) :: (taggedValue: CValue) :: _ => fromCbor(taggedValue)
       case (cValue: CValue) :: _ => fromCbor(cValue)
       case Nil => Xor.left(CborDecodingFailed())
     }

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,38 +1,19 @@
 package io.mediachain.transactor
 
-import io.mediachain.transactor.TypeSerialization.CBORTypeNames
+import io.mediachain.transactor.CborSerialization.CBORTypeNames
 
 
 object Types {
   import scala.concurrent.Future
   import cats.data.Xor
 
-  import io.mediachain.util.cbor.CborCodec
+  import io.mediachain.transactor.CborSerialization.CborSerializable
   import io.mediachain.util.cbor.CborAST._
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable with CborSerializable
 
-  trait CborSerializable {
-    val CBORType: String
 
-    def toCborBytes: Array[Byte] = CborCodec.encode(toCbor)
-
-    def toCbor: CValue =
-      toCMapWithDefaults(Map.empty, Map.empty)
-
-    def toCMapWithDefaults(defaults: Map[String, CValue],
-                           optionals: Map[String, Option[CValue]])
-    : CMap = {
-      val merged = defaults ++ optionals.flatMap {
-        case (_, None) => List.empty
-        case (k, Some(v)) => List(k -> v)
-      }
-      val withType = ("type", CString(CBORType)) :: merged.toList
-
-      CMap.withStringKeys(withType)
-    }
-  }
 
   // Mediachain Datastore Records
   sealed abstract class Record extends DataObject {

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,6 +1,5 @@
 package io.mediachain.transactor
 
-import io.mediachain.transactor.CborSerialization.CBORTypeNames
 
 
 object Types {
@@ -9,6 +8,7 @@ object Types {
 
   import io.mediachain.transactor.CborSerialization.CborSerializable
   import io.mediachain.util.cbor.CborAST._
+  import io.mediachain.transactor.CborSerialization.CborTypeNames
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable with CborSerializable
@@ -50,7 +50,7 @@ object Types {
   case class Entity(
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = CBORTypeNames.Entity
+    val CBORType = Some(CborTypeNames.Entity)
     override def toCbor =
       super.toCMapWithDefaults(meta, Map())
 
@@ -60,7 +60,7 @@ object Types {
   case class Artefact( 
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = CBORTypeNames.Artefact
+    val CBORType = Some(CborTypeNames.Artefact)
     override def toCbor =
       super.toCMapWithDefaults(meta, Map())
     
@@ -77,7 +77,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = CBORTypeNames.EntityChainCell
+    val CBORType = Some(CborTypeNames.EntityChainCell)
 
     override def toCbor = {
       val defaults = meta + ("entity" -> entity.toCbor)
@@ -91,7 +91,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = CBORTypeNames.ArtefactChainCell
+    val CBORType = Some(CborTypeNames.ArtefactChainCell)
 
     override def toCbor = {
       val defaults = meta + ("artefact" -> artefact.toCbor)
@@ -110,7 +110,7 @@ object Types {
     index: BigInt,
     ref: Reference
   ) extends JournalEntry {
-    val CBORType = CBORTypeNames.CanonicalEntry
+    val CBORType = Some(CborTypeNames.CanonicalEntry)
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -128,7 +128,7 @@ object Types {
     chain: Reference,
     chainPrevious: Option[Reference]
   ) extends JournalEntry {
-    val CBORType = CBORTypeNames.ChainEntry
+    val CBORType = Some(CborTypeNames.ChainEntry)
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -149,7 +149,7 @@ object Types {
     chain: Option[Reference],
     entries: Array[JournalEntry]
   ) extends DataObject {
-    val CBORType = CBORTypeNames.JournalBlock
+    val CBORType = Some(CborTypeNames.JournalBlock)
 
     override def toCbor = {
       val cborEntries = CArray(entries.map(_.toCbor).toList)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -9,7 +9,7 @@ object Types {
 
   import io.mediachain.transactor.CborSerialization.CborSerializable
   import io.mediachain.util.cbor.CborAST._
-  import io.mediachain.transactor.CborSerialization.CborTypeNames
+  import io.mediachain.transactor.CborSerialization.MediachainTypes
 
   // Base class of all objects storable in the Datastore
   sealed abstract class DataObject extends Serializable with CborSerializable
@@ -26,7 +26,7 @@ object Types {
 
   // Content-addressable reference using IPFS MultiHash
   case class MultihashReference(multihash: MultiHash) extends Reference {
-    val CBORType = None
+    val mediachainType = None
 
     override def toCbor: CValue =
       CMap.withStringKeys("@link" -> CBytes(multihash.bytes))
@@ -59,7 +59,7 @@ object Types {
   case class Entity(
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = Some(CborTypeNames.Entity)
+    val mediachainType = Some(MediachainTypes.Entity)
     override def toCbor =
       super.toCMapWithDefaults(meta, Map())
 
@@ -69,7 +69,7 @@ object Types {
   case class Artefact( 
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val CBORType = Some(CborTypeNames.Artefact)
+    val mediachainType = Some(MediachainTypes.Artefact)
     override def toCbor =
       super.toCMapWithDefaults(meta, Map())
     
@@ -86,7 +86,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = Some(CborTypeNames.EntityChainCell)
+    val mediachainType = Some(MediachainTypes.EntityChainCell)
 
     override def toCbor = {
       val defaults = meta + ("entity" -> entity.toCbor)
@@ -100,7 +100,7 @@ object Types {
     chain: Option[Reference],
     meta: Map[String, CValue]
   ) extends ChainCell {
-    val CBORType = Some(CborTypeNames.ArtefactChainCell)
+    val mediachainType = Some(MediachainTypes.ArtefactChainCell)
 
     override def toCbor = {
       val defaults = meta + ("artefact" -> artefact.toCbor)
@@ -119,7 +119,7 @@ object Types {
     index: BigInt,
     ref: Reference
   ) extends JournalEntry {
-    val CBORType = Some(CborTypeNames.CanonicalEntry)
+    val mediachainType = Some(MediachainTypes.CanonicalEntry)
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -137,7 +137,7 @@ object Types {
     chain: Reference,
     chainPrevious: Option[Reference]
   ) extends JournalEntry {
-    val CBORType = Some(CborTypeNames.ChainEntry)
+    val mediachainType = Some(MediachainTypes.ChainEntry)
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -158,7 +158,7 @@ object Types {
     chain: Option[Reference],
     entries: Array[JournalEntry]
   ) extends DataObject {
-    val CBORType = Some(CborTypeNames.JournalBlock)
+    val mediachainType = Some(MediachainTypes.JournalBlock)
 
     override def toCbor = {
       val cborEntries = CArray(entries.map(_.toCbor).toList)

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -1,5 +1,6 @@
 package io.mediachain.transactor
 
+import io.mediachain.multihash.MultiHash
 
 
 object Types {
@@ -22,6 +23,14 @@ object Types {
 
   // References to records in the underlying datastore
   abstract class Reference extends Serializable with CborSerializable
+
+  // Content-addressable reference using IPFS MultiHash
+  case class MultihashReference(multihash: MultiHash) extends Reference {
+    val CBORType = None
+
+    override def toCbor: CValue =
+      CMap.withStringKeys("@link" -> CBytes(multihash.bytes))
+  }
 
   // Typed References for tracking chain heads in the StateMachine
   sealed abstract class ChainReference extends Serializable {

--- a/transactor/src/main/scala/io/mediachain/transactor/Types.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Types.scala
@@ -43,26 +43,19 @@ object Types {
   abstract class Reference extends Serializable with CborSerializable
 
   // Typed References for tracking chain heads in the StateMachine
-  sealed abstract class ChainReference extends Serializable with CborSerializable {
+  sealed abstract class ChainReference extends Serializable {
     def chain: Option[Reference]
-
-    override def toCbor =
-      toCMapWithDefaults(Map(), Map("chain" -> chain.map(_.toCbor)))
   }
 
   case class EntityChainReference(chain: Option[Reference])
-    extends ChainReference {
-    val CBORType = CBORTypeNames.EntityChainReference
-  }
+    extends ChainReference
 
   object EntityChainReference {
     def empty = EntityChainReference(None)
   }
 
   case class ArtefactChainReference(chain: Option[Reference])
-    extends ChainReference {
-    val CBORType = CBORTypeNames.ArtefactChainReference
-  }
+    extends ChainReference
 
   object ArtefactChainReference {
     def empty = ArtefactChainReference(None)
@@ -78,7 +71,7 @@ object Types {
   ) extends CanonicalRecord {
     val CBORType = CBORTypeNames.Entity
     override def toCbor =
-      super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
+      super.toCMapWithDefaults(meta, Map())
 
     def reference: ChainReference = EntityChainReference.empty
   }
@@ -88,7 +81,7 @@ object Types {
   ) extends CanonicalRecord {
     val CBORType = CBORTypeNames.Artefact
     override def toCbor =
-      super.toCMapWithDefaults(meta + ("reference" -> reference.toCbor), Map())
+      super.toCMapWithDefaults(meta, Map())
     
     def reference: ChainReference = ArtefactChainReference.empty
   }

--- a/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -12,8 +12,8 @@ object CborAST {
 
 
   sealed trait CValue
-  case class CNull() extends CValue
-  case class CUndefined() extends CValue
+  case object CNull extends CValue
+  case object CUndefined extends CValue
   case class CTag(tag: Long) extends CValue
   case class CInt(num: BigInt) extends CValue
   case class CDouble(num: Double) extends CValue
@@ -62,8 +62,8 @@ object CborAST {
   }
 
   def toDataItem(cValue: CValue): Cbor.DataItem = cValue match {
-    case _: CNull => Cbor.SimpleValue.NULL
-    case _: CUndefined => Cbor.SimpleValue.UNDEFINED
+    case CNull => Cbor.SimpleValue.NULL
+    case CUndefined => Cbor.SimpleValue.UNDEFINED
     case CTag(tag) => new Cbor.Tag(tag)
     case CInt(num) => converter.convert(num)
     case CDouble(num) => converter.convert(num)
@@ -100,9 +100,9 @@ object CborAST {
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.FALSE =>
       CBool(false)
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.NULL =>
-      CNull()
+      CNull
     case s: Cbor.SimpleValue if s.getSimpleValueType == SimpleValueType.UNDEFINED =>
-      CUndefined()
+      CUndefined
 
     case i: Cbor.UnsignedInteger => CInt(i.getValue)
     case i: Cbor.NegativeInteger => CInt(i.getValue)

--- a/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
+++ b/transactor/src/main/scala/io/mediachain/util/cbor/JValueConversions.scala
@@ -8,8 +8,8 @@ object JValueConversions {
 
   def jValueToCbor(jValue: JValue): CValue = {
     jValue match {
-      case JNull => CNull()
-      case JNothing => CUndefined()
+      case JNull => CNull
+      case JNothing => CUndefined
       case JInt(num) => CInt(num)
       case JLong(num) => CInt(num)
       case JDecimal(num) => CDouble(num.doubleValue)

--- a/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
@@ -1,6 +1,9 @@
 package io.mediachain.transactor
 
+import java.nio.charset.StandardCharsets
+
 import io.mediachain.BaseSpec
+import io.mediachain.multihash.MultiHash
 import org.specs2.matcher.Matcher
 
 object CborSerializationSpec extends BaseSpec {
@@ -23,38 +26,44 @@ object CborSerializationSpec extends BaseSpec {
           - journal block $roundTripJournalBlock
       """
 
+  def multihashRef(content: String): MultihashReference = {
+    MultihashReference(
+      MultiHash.hashWithSHA256(content.getBytes(StandardCharsets.UTF_8))
+    )
+  }
+
   private object Fixtures {
 
     val entity = Entity(meta = Map("foo" -> CString("bar")))
     val artefact = Artefact(meta = Map("bar" -> CString("baz")))
 
     val entityChainCell = EntityChainCell(
-      entity = new DummyReference(0),
+      entity = multihashRef("foo"),
       chain = None,
       meta = Map("created" -> CString("the past"))
     )
 
     val artefactChainCell = ArtefactChainCell(
-      artefact = new DummyReference(1),
+      artefact = multihashRef("bar"),
       chain = None,
        meta = Map("created" -> CString("the past"))
     )
 
     val canonicalEntry = CanonicalEntry(
       index = 42,
-      ref = new DummyReference(0)
+      ref = multihashRef("foo")
     )
 
     val chainEntry = ChainEntry(
       index = 43,
-      ref = new DummyReference(0),
-      chain = new DummyReference(2),
+      ref = multihashRef("foo"),
+      chain = multihashRef("baz"),
       chainPrevious = None
     )
 
     val journalBlock = JournalBlock(
       index = 44,
-      chain = Some(new DummyReference(3)),
+      chain = Some(multihashRef("blammo")),
       entries = Array(canonicalEntry, chainEntry)
     )
   }

--- a/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
@@ -3,9 +3,9 @@ package io.mediachain.transactor
 import io.mediachain.BaseSpec
 import org.specs2.matcher.Matcher
 
-object TypeSerializationSpec extends BaseSpec {
+object CborSerializationSpec extends BaseSpec {
   import io.mediachain.transactor.Types._
-  import io.mediachain.transactor.TypeSerialization._
+  import io.mediachain.transactor.CborSerialization._
   import io.mediachain.util.cbor.CborAST._
   import io.mediachain.transactor.Dummies.DummyReference
 

--- a/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
@@ -59,20 +59,20 @@ object CborSerializationSpec extends BaseSpec {
     )
   }
 
-  def matchTypeName(typeName: CborTypeName): Matcher[CValue] =
+  def matchTypeName(typeName: MediachainType): Matcher[CValue] =
     beLike {
       case m: CMap =>
         m.asStringKeyedMap must havePair ("type" -> CString(typeName.stringValue))
     }
 
   def encodesTypeName = {
-    Fixtures.entity.toCbor must matchTypeName(CborTypeNames.Entity)
-    Fixtures.artefact.toCbor must matchTypeName(CborTypeNames.Artefact)
-    Fixtures.entityChainCell.toCbor must matchTypeName(CborTypeNames.EntityChainCell)
-    Fixtures.artefactChainCell.toCbor must matchTypeName(CborTypeNames.ArtefactChainCell)
-    Fixtures.canonicalEntry.toCbor must matchTypeName(CborTypeNames.CanonicalEntry)
-    Fixtures.chainEntry.toCbor must matchTypeName(CborTypeNames.ChainEntry)
-    Fixtures.journalBlock.toCbor must matchTypeName(CborTypeNames.JournalBlock)
+    Fixtures.entity.toCbor must matchTypeName(MediachainTypes.Entity)
+    Fixtures.artefact.toCbor must matchTypeName(MediachainTypes.Artefact)
+    Fixtures.entityChainCell.toCbor must matchTypeName(MediachainTypes.EntityChainCell)
+    Fixtures.artefactChainCell.toCbor must matchTypeName(MediachainTypes.ArtefactChainCell)
+    Fixtures.canonicalEntry.toCbor must matchTypeName(MediachainTypes.CanonicalEntry)
+    Fixtures.chainEntry.toCbor must matchTypeName(MediachainTypes.ChainEntry)
+    Fixtures.journalBlock.toCbor must matchTypeName(MediachainTypes.JournalBlock)
   }
 
   def roundTripEntity =

--- a/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/CborSerializationSpec.scala
@@ -59,20 +59,20 @@ object CborSerializationSpec extends BaseSpec {
     )
   }
 
-  def matchTypeName(typeName: String): Matcher[CValue] =
+  def matchTypeName(typeName: CborTypeName): Matcher[CValue] =
     beLike {
       case m: CMap =>
-        m.asStringKeyedMap must havePair ("type" -> CString(typeName))
+        m.asStringKeyedMap must havePair ("type" -> CString(typeName.stringValue))
     }
 
   def encodesTypeName = {
-    Fixtures.entity.toCbor must matchTypeName(CBORTypeNames.Entity)
-    Fixtures.artefact.toCbor must matchTypeName(CBORTypeNames.Artefact)
-    Fixtures.entityChainCell.toCbor must matchTypeName(CBORTypeNames.EntityChainCell)
-    Fixtures.artefactChainCell.toCbor must matchTypeName(CBORTypeNames.ArtefactChainCell)
-    Fixtures.canonicalEntry.toCbor must matchTypeName(CBORTypeNames.CanonicalEntry)
-    Fixtures.chainEntry.toCbor must matchTypeName(CBORTypeNames.ChainEntry)
-    Fixtures.journalBlock.toCbor must matchTypeName(CBORTypeNames.JournalBlock)
+    Fixtures.entity.toCbor must matchTypeName(CborTypeNames.Entity)
+    Fixtures.artefact.toCbor must matchTypeName(CborTypeNames.Artefact)
+    Fixtures.entityChainCell.toCbor must matchTypeName(CborTypeNames.EntityChainCell)
+    Fixtures.artefactChainCell.toCbor must matchTypeName(CborTypeNames.ArtefactChainCell)
+    Fixtures.canonicalEntry.toCbor must matchTypeName(CborTypeNames.CanonicalEntry)
+    Fixtures.chainEntry.toCbor must matchTypeName(CborTypeNames.ChainEntry)
+    Fixtures.journalBlock.toCbor must matchTypeName(CborTypeNames.JournalBlock)
   }
 
   def roundTripEntity =

--- a/transactor/src/test/scala/io/mediachain/transactor/TypeSerializationSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/transactor/TypeSerializationSpec.scala
@@ -18,8 +18,6 @@ object TypeSerializationSpec extends BaseSpec {
           - artefact $roundTripArtefact
           - entity chain cell $roundTripEntityChainCell
           - artefact chain cell $roundTripArtefactChainCell
-          - entity chain reference $roundTripEntityChainRef
-          - artefact chain reference $roundTripArtefactChainRef
           - canonical journal entry $roundTripCanonicalEntry
           - chain journal entry $roundTripChainEntry
           - journal block $roundTripJournalBlock
@@ -40,14 +38,6 @@ object TypeSerializationSpec extends BaseSpec {
       artefact = new DummyReference(1),
       chain = None,
        meta = Map("created" -> CString("the past"))
-    )
-
-    val entityChainRef = EntityChainReference(
-      chain = Some(new DummyReference(2))
-    )
-
-    val artefactChainRef = ArtefactChainReference(
-      chain = Some(new DummyReference(3))
     )
 
     val canonicalEntry = CanonicalEntry(
@@ -80,8 +70,6 @@ object TypeSerializationSpec extends BaseSpec {
     Fixtures.artefact.toCbor must matchTypeName(CBORTypeNames.Artefact)
     Fixtures.entityChainCell.toCbor must matchTypeName(CBORTypeNames.EntityChainCell)
     Fixtures.artefactChainCell.toCbor must matchTypeName(CBORTypeNames.ArtefactChainCell)
-    Fixtures.entityChainRef.toCbor must matchTypeName(CBORTypeNames.EntityChainReference)
-    Fixtures.artefactChainRef.toCbor must matchTypeName(CBORTypeNames.ArtefactChainReference)
     Fixtures.canonicalEntry.toCbor must matchTypeName(CBORTypeNames.CanonicalEntry)
     Fixtures.chainEntry.toCbor must matchTypeName(CBORTypeNames.ChainEntry)
     Fixtures.journalBlock.toCbor must matchTypeName(CBORTypeNames.JournalBlock)
@@ -89,32 +77,28 @@ object TypeSerializationSpec extends BaseSpec {
 
   def roundTripEntity =
     fromCbor(Fixtures.entity.toCbor) must beRightXor { entity =>
-      entity.asInstanceOf[Entity].meta must havePair("foo" -> CString("bar"))
+      entity.asInstanceOf[Entity].meta must havePairs(Fixtures.entity.meta.toList:_*)
     }
 
   def roundTripArtefact =
     fromCbor(Fixtures.artefact.toCbor) must beRightXor { entity =>
-      entity.asInstanceOf[Artefact].meta must havePair("bar" -> CString("baz"))
+      entity.asInstanceOf[Artefact].meta must havePairs(Fixtures.artefact.meta.toList:_*)
     }
 
   def roundTripEntityChainCell =
     fromCbor(Fixtures.entityChainCell.toCbor) must beRightXor { cell =>
-      cell.asInstanceOf[EntityChainCell] must_== Fixtures.entityChainCell
+      val entityCell = cell.asInstanceOf[EntityChainCell]
+      entityCell.entity must_== Fixtures.entityChainCell.entity
+      entityCell.chain must_== Fixtures.entityChainCell.chain
+      entityCell.meta must havePairs(Fixtures.entityChainCell.meta.toList:_*)
     }
 
   def roundTripArtefactChainCell =
     fromCbor(Fixtures.artefactChainCell.toCbor) must beRightXor { cell =>
-      cell.asInstanceOf[ArtefactChainCell] must_== Fixtures.artefactChainCell
-    }
-
-  def roundTripEntityChainRef =
-    fromCbor(Fixtures.entityChainRef.toCbor) must beRightXor { ref =>
-      ref.asInstanceOf[EntityChainReference] must_== Fixtures.entityChainRef
-    }
-
-  def roundTripArtefactChainRef =
-    fromCbor(Fixtures.artefactChainRef.toCbor) must beRightXor { ref =>
-      ref.asInstanceOf[ArtefactChainReference] must_== Fixtures.artefactChainRef
+      val artefactCell = cell.asInstanceOf[ArtefactChainCell]
+      artefactCell.artefact must_== Fixtures.artefactChainCell.artefact
+      artefactCell.chain must_== Fixtures.artefactChainCell.chain
+      artefactCell.meta must havePairs(Fixtures.artefactChainCell.meta.toList:_*)
     }
 
   def roundTripCanonicalEntry =

--- a/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
+++ b/transactor/src/test/scala/io/mediachain/util/cbor/CValueGenerators.scala
@@ -8,8 +8,8 @@ import co.nstant.in.cbor.model.{DataItem, RationalNumber, UnsignedInteger, Langu
 object CValueGenerators {
 
 
-  val genCNull = Gen.const(CNull())
-  val genCUndefined = Gen.const(CUndefined())
+  val genCNull = Gen.const(CNull)
+  val genCUndefined = Gen.const(CUndefined)
   val genCTag = for (t <- arbitrary[Long]) yield CTag(t)
   val genCInt = for (i <- arbitrary[BigInt]) yield CInt(i)
   val genCDouble = for (d <- arbitrary[Double]) yield CDouble(d)


### PR DESCRIPTION
- Adds a `CborDeserializer[T]` trait that's extended by singleton objects for each `CborSerializable` type we want to decode.  
- Replaces the `typeName match { ... }`  construct in the `fromCMap` method with a `Map[String, CborDeserializer[CborSerializable]]` which is used to look up the deserializer for a given type name.
- Removes the `CborSerializable` trait from the `ChainReference` types, since they're internal to the transactor.
- Renames the `TypeSerialization` object to `CborSerialization`, since we also have pojo serialization for some types.
