### PR TITLE
copycat serializers

### DIFF
--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -103,10 +103,15 @@ object Copycat {
   }
 
   object Serializers {
+    val klasses = List(classOf[JournalInsert],
+                       classOf[JournalUpdate],
+                       classOf[JournalLookup],
+                       classOf[JournalCurrentBlock],
+                       classOf[JournalCommitEvent],
+                       classOf[JournalBlockEvent],
+                       classOf[JournalState])
     def register(serializer: Serializer) {
-      // XXX temporary to enable blancket use of Serializables
-      // TODO register all used classes with the serializer
-      serializer.disableWhitelist()
+      klasses.foreach(serializer.register(_))
     }
   }
   


### PR DESCRIPTION
#22
- Drops the whitelist for copycat serialization and registers all types that are directly serialized.
- The JournalStateMachine is refactored to keep the serialized state in a single object.
