### PR TITLE
yn-chain-types: support chain cell subtypes in state machine

### DIFF
--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -15,7 +15,6 @@ import cats.data.Xor
 
 object Copycat {
   import io.mediachain.transactor.StateMachine._
-  import io.mediachain.types.Datastore
   import io.mediachain.types.Datastore._
   import io.mediachain.types.Transactor._
 

--- a/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/StateMachine.scala
@@ -98,7 +98,7 @@ object StateMachine {
           (cref, cell) match {
             case (EntityChainReference(chain), EntityChainCell(entity, xchain, meta)) => {
               if (checkUpdate(ref, chain, entity, xchain)) {
-                val newcell = EntityChainCell(ref, chain, meta)
+                val newcell = cell.cons(chain)
                 val newchain = datastore.put(newcell)
                 index.put(ref, EntityChainReference(Some(newchain)))
                 commit(ref, newchain, chain)
@@ -106,7 +106,7 @@ object StateMachine {
             }
             case (ArtefactChainReference(chain), ArtefactChainCell(artefact, xchain, meta)) => {
               if (checkUpdate(ref, chain, artefact, xchain)) {
-                val newcell = ArtefactChainCell(ref, chain, meta)
+                val newcell = cell.cons(chain)
                 val newchain = datastore.put(newcell)
                 index.put(ref, ArtefactChainReference(Some(newchain)))
                 commit(ref, newchain, chain)

--- a/transactor/src/main/scala/io/mediachain/types/Datastore.scala
+++ b/transactor/src/main/scala/io/mediachain/types/Datastore.scala
@@ -65,6 +65,7 @@ object Datastore {
   // Chain cells
   sealed abstract class ChainCell extends Record {
     def chain: Option[Reference]
+    def cons(chain: Option[Reference]): ChainCell
   }
 
   class EntityChainCell(
@@ -72,6 +73,9 @@ object Datastore {
     val chain: Option[Reference],
     val meta: Map[String, CValue]
   ) extends ChainCell {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      EntityChainCell(entity, xchain, meta)
+
     val mediachainType: Option[MediachainType] =
       meta.get("type")
         .flatMap(t => MediachainTypes.fromCValue(t).toOption)
@@ -97,6 +101,9 @@ object Datastore {
     val chain: Option[Reference],
     val meta: Map[String, CValue]
   ) extends ChainCell {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      ArtefactChainCell(artefact, xchain, meta)
+    
     val mediachainType: Option[MediachainType] =
       meta.get("type")
         .flatMap(t => MediachainTypes.fromCValue(t).toOption)
@@ -124,6 +131,9 @@ object Datastore {
     override val chain: Option[Reference],
     override val meta: Map[String,CValue]
   ) extends EntityChainCell(entity, chain, meta) {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      EntityUpdateCell(entity, xchain, meta)
+
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.EntityUpdateCell)
   }
@@ -135,6 +145,9 @@ object Datastore {
     entityLink: Reference
   ) extends EntityChainCell(entity, chain, meta)
   {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      EntityLinkCell(entity, xchain, meta, entityLink)
+
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.EntityLinkCell)
 
@@ -153,6 +166,9 @@ object Datastore {
     override val chain: Option[Reference],
     override val meta: Map[String, CValue]
   ) extends ArtefactChainCell(artefact, chain, meta) {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      ArtefactUpdateCell(artefact, xchain, meta)
+
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.ArtefactUpdateCell)
   }
@@ -164,6 +180,9 @@ object Datastore {
     entity: Reference
   ) extends ArtefactChainCell(artefact, chain, meta)
   {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      ArtefactCreationCell(artefact, xchain, meta, entity)
+
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.ArtefactCreationCell)
 
@@ -182,6 +201,9 @@ object Datastore {
     artefactOrigin: Reference
   ) extends ArtefactChainCell(artefact, chain, meta)
   {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      ArtefactDerivationCell(artefact, xchain, meta, artefactOrigin)
+
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.ArtefactDerivationCell)
 
@@ -201,6 +223,9 @@ object Datastore {
     entity: Reference
   ) extends ArtefactChainCell(artefact, chain, meta)
   {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      ArtefactOwnershipCell(artefact, xchain, meta, entity)
+
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.ArtefactOwnershipCell)
 
@@ -219,6 +244,9 @@ object Datastore {
     entity: Reference
   ) extends ArtefactChainCell(artefact, chain, meta)
   {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      ArtefactReferenceCell(artefact, xchain, meta, entity)
+
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.ArtefactReferenceCell)
 


### PR DESCRIPTION
#54
- adds a cons method to ChainCells for consing on top of a chain
- modifies the state machine to use cons for constructing the actual chain cells
