### PR TITLE
Perisistent Datastore implementation

### DIFF
--- a/transactor/src/main/scala/io/mediachain/datastore/DynamoDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/DynamoDatastore.scala
@@ -8,14 +8,13 @@ import scala.collection.mutable.{Buffer, ArrayBuffer}
 import io.mediachain.multihash.MultiHash
 import io.mediachain.protocol.Datastore.DatastoreException
 
-// TODO error handling
-//      queued eventual writes in the background with disk backing of 
-//       in-progress writes
-//      use batch writes for chunked puts
-class DynamoDatastore(table: String, creds: BasicAWSCredentials)
+// TODO use batch read/writes for chunked get/puts
+class DynamoDatastore(config: DynamoDatastore.Config)
   extends BinaryDatastore with AutoCloseable {
   import scala.collection.JavaConversions._
   
+  val creds = config.awscreds
+  val table = config.baseTable
   val chunkSize = 1024 * 384 // 384 KB; DynamoDB has 400KB limit
   val chunkTable = table + "Chunks"
   
@@ -155,4 +154,8 @@ class DynamoDatastore(table: String, creds: BasicAWSCredentials)
   
   private def buffer2Bytes(buf: ByteBuffer) = 
     buf.array
+}
+
+object DynamoDatastore {
+  case class Config(baseTable: String, awscreds: BasicAWSCredentials)
 }

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -40,8 +40,9 @@ class PersistentDatastore(config: PersistentDatastore.Config)
   }
   
   private def recover() {
-    // XXX Implement me: crash recovery
-    //     enqueue all rocks persisted keys for write through to dynamo
+    // Crash recovery: schedule all keys still in rocks db for
+    //  write-through to dynamo
+    rocks.synchronized {rocks.getKeys}.foreach {key => queue.putLast(key)}
   }
   
   private def loop(backoff: Int) {

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -41,7 +41,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
       loop(0)
     } catch {
       case e: InterruptedException => ()
-      case e: Throwable => logger.error("Unhandled exception", e)
+      case e: Throwable => logger.error("FATAL: Unhandled exception in background write thread", e)
     }
   }
   

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -71,7 +71,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
         key
       }
     } catch {
-      case e: AmazonServiceException => {
+      case e @ (_: AmazonServiceException | _: DatastoreException) => {
         // XXX log exception
         queue.addFirst(key)
         None

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -21,7 +21,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
   }
 
   override def getData(key: MultiHash): Option[Array[Byte]] = {
-    rocks.getData(key).orElse {dynamo.synchronized {dynamo.getData(key)}}
+    rocks.getData(key).orElse {dynamo.getData(key)}
   }
   
   override def close() {
@@ -66,7 +66,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
     val key = queue.takeFirst
     try {
       rocks.getData(key).map { data =>
-        dynamo.synchronized {dynamo.putData(key, data)}
+        dynamo.putData(key, data)
         key
       }
     } catch {

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -4,7 +4,6 @@ import java.util.Random
 import java.util.concurrent.LinkedBlockingDeque
 import com.amazonaws.AmazonServiceException
 import io.mediachain.multihash.MultiHash
-import io.mediachain.protocol.Datastore.DatastoreException
 
 class PersistentDatastore(config: PersistentDatastore.Config)
   extends BinaryDatastore with AutoCloseable with Runnable {
@@ -72,7 +71,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
         key
       }
     } catch {
-      case e @ (_: AmazonServiceException | _: DatastoreException) => {
+      case e: AmazonServiceException => {
         // XXX log exception
         queue.addFirst(key)
         None

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -80,7 +80,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
     } catch {
       case e: AmazonServiceException => {
         logger.error("AWS Error writing " + key.base58, e)
-        queue.addFirst(key)
+        queue.putFirst(key)
         None
       }
     }

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -57,18 +57,16 @@ class PersistentDatastore(config: PersistentDatastore.Config)
   private def loop(backoff: Int) {
     if (!Thread.interrupted) {
       writeNext() match {
-        case Some(key) => {
+        case Some(key) =>
           rocks.removeData(key)
           loop(0)
-        }
           
-        case None => {
+        case None => 
           val xbackoff = Math.min(maxBackoffRetry, Math.max(1, 2 * backoff))
           val sleep = random.nextInt(1000 * xbackoff)
           logger.info("Backing off for " + sleep + "ms")
           Thread.sleep(sleep)
           loop(xbackoff)
-        }
       }
     }
   }
@@ -81,11 +79,10 @@ class PersistentDatastore(config: PersistentDatastore.Config)
         key
       }
     } catch {
-      case e: AmazonServiceException => {
+      case e: AmazonServiceException =>
         logger.error("AWS Error writing " + key.base58, e)
         queue.putFirst(key)
         None
-      }
     }
   }
 }

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -1,0 +1,85 @@
+package io.mediachain.datastore
+
+import java.util.Random
+import java.util.concurrent.LinkedBlockingDeque
+import com.amazonaws.AmazonServiceException
+import io.mediachain.multihash.MultiHash
+import io.mediachain.protocol.Datastore.DatastoreException
+
+class PersistentDatastore(config: PersistentDatastore.Config)
+  extends BinaryDatastore with AutoCloseable with Runnable {
+  
+  val dynamo = new DynamoDatastore(config.dynamo)
+  val rocks = new RocksDatastore(config.rocks)
+  val queue = new LinkedBlockingDeque[MultiHash]
+  val writer = new Thread(this)
+  val random = new Random
+  val maxBackoffRetry = 60 // seconds
+
+  override def putData(key: MultiHash, value: Array[Byte]) {
+    rocks.synchronized {rocks.putData(key, value)}
+    queue.putLast(key)
+  }
+
+  override def getData(key: MultiHash): Option[Array[Byte]] = {
+    rocks.synchronized {rocks.getData(key)}
+      .orElse {dynamo.synchronized {dynamo.getData(key)}}
+  }
+  
+  override def close() {
+    writer.interrupt()
+    writer.join()
+    rocks.close()
+    dynamo.close()
+  }
+  
+  // background writer
+  override def run() {
+    recover()
+    loop(0)
+  }
+  
+  private def recover() {
+    // XXX Implement me: crash recovery
+    //     enqueue all rocks persisted keys for write through to dynamo
+  }
+  
+  private def loop(backoff: Int) {
+    if (!Thread.interrupted) {
+      writeNext() match {
+        case Some(key) => {
+          rocks.synchronized {rocks.removeData(key)}
+          loop(0)
+        }
+          
+        case None => {
+          val xbackoff = Math.min(maxBackoffRetry, Math.max(1, 2 * backoff))
+          val sleep = random.nextInt(1000 * xbackoff)
+          // XXX log sleep?
+          Thread.sleep(sleep)
+          loop(xbackoff)
+        }
+      }
+    }
+  }
+  
+  private def writeNext(): Option[MultiHash] = {
+    val key = queue.takeFirst
+    try {
+      rocks.synchronized {rocks.getData(key)}.map { data =>
+        dynamo.synchronized {dynamo.putData(key, data)}
+        key
+      }
+    } catch {
+      case e: AmazonServiceException => {
+        // XXX log exception
+        queue.addFirst(key)
+        None
+      }
+    }
+  }
+}
+
+object PersistentDatastore {
+  case class Config(dynamo: DynamoDatastore.Config, rocks: String)
+}

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -12,11 +12,12 @@ class PersistentDatastore(config: PersistentDatastore.Config)
   val logger = LoggerFactory.getLogger(classOf[PersistentDatastore])
   val dynamo = new DynamoDatastore(config.dynamo)
   val rocks = new RocksDatastore(config.rocks)
+  val random = new Random
+  val maxBackoffRetry = 60 // second
   val queue = new LinkedBlockingDeque[MultiHash]
   val writer = new Thread(this)
-  val random = new Random
-  val maxBackoffRetry = 60 // seconds
-
+  writer.start()
+  
   override def putData(key: MultiHash, value: Array[Byte]) {
     rocks.putData(key, value)
     queue.putLast(key)

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -15,8 +15,11 @@ class PersistentDatastore(config: PersistentDatastore.Config)
   val random = new Random
   val maxBackoffRetry = 60 // second
   val queue = new LinkedBlockingDeque[MultiHash]
-  val writer = new Thread(this, "PersistentDataStore#write")
-  writer.start()
+  val writer = new Thread(this, s"PersistentDataStore@${this.hashCode}#write")
+  
+  def start() {
+    writer.start()
+  }
   
   override def putData(key: MultiHash, value: Array[Byte]) {
     rocks.putData(key, value)

--- a/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
@@ -1,6 +1,7 @@
 package io.mediachain.datastore
 
 import org.rocksdb._
+import scala.collection.mutable.ListBuffer
 import io.mediachain.multihash.MultiHash
 
 class RocksDatastore(path: String)
@@ -20,6 +21,17 @@ class RocksDatastore(path: String)
   
   def removeData(key: MultiHash) {
     db.remove(key.bytes)
+  }
+  
+  def getKeys(): List[MultiHash] = {
+    val keys = new ListBuffer[MultiHash]
+    val iter = db.newIterator
+    iter.seekToFirst
+    while (iter.isValid) {
+      MultiHash.fromBytes(iter.key).foreach {key => keys += key}
+      iter.next
+    }
+    keys.toList
   }
 }
 

--- a/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
@@ -9,31 +9,29 @@ class RocksDatastore(path: String)
   val db = RocksDB.open(path)
   
   override def putData(key: MultiHash, data: Array[Byte]) {
-    this.synchronized {db.put(key.bytes, data)}
+    db.put(key.bytes, data)
   }
   
   override def close() {
-    this.synchronized {db.close()}
+    db.close()
   }
   
   override def getData(key: MultiHash): Option[Array[Byte]] = 
-    this.synchronized {Option(db.get(key.bytes))}
+    Option(db.get(key.bytes))
   
   def removeData(key: MultiHash) {
-    this.synchronized {db.remove(key.bytes)}
+    db.remove(key.bytes)
   }
   
-  def getKeys(): List[MultiHash] = 
-    this.synchronized {
-      val keys = new ListBuffer[MultiHash]
-      val iter = db.newIterator
-      iter.seekToFirst
-      while (iter.isValid) {
-        MultiHash.fromBytes(iter.key).foreach {key => keys += key}
-        iter.next
-      }
-      keys.toList
+  def getKeys(): List[MultiHash] = {
+    val keys = new ListBuffer[MultiHash]
+    val iter = db.newIterator
+    iter.seekToFirst
+    while (iter.isValid) {
+      MultiHash.fromBytes(iter.key).foreach {key => keys += key}
+      iter.next
     }
-  
+    keys.toList
+  }
 }
 

--- a/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
@@ -17,5 +17,9 @@ class RocksDatastore(path: String)
   
   override def getData(key: MultiHash): Option[Array[Byte]] = 
     Option(db.get(key.bytes))
+  
+  def removeData(key: MultiHash) {
+    // XXX Implement me!
+  }
 }
 

--- a/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
@@ -9,29 +9,31 @@ class RocksDatastore(path: String)
   val db = RocksDB.open(path)
   
   override def putData(key: MultiHash, data: Array[Byte]) {
-    db.put(key.bytes, data)
+    this.synchronized {db.put(key.bytes, data)}
   }
   
   override def close() {
-    db.close()
+    this.synchronized {db.close()}
   }
   
   override def getData(key: MultiHash): Option[Array[Byte]] = 
-    Option(db.get(key.bytes))
+    this.synchronized {Option(db.get(key.bytes))}
   
   def removeData(key: MultiHash) {
-    db.remove(key.bytes)
+    this.synchronized {db.remove(key.bytes)}
   }
   
-  def getKeys(): List[MultiHash] = {
-    val keys = new ListBuffer[MultiHash]
-    val iter = db.newIterator
-    iter.seekToFirst
-    while (iter.isValid) {
-      MultiHash.fromBytes(iter.key).foreach {key => keys += key}
-      iter.next
+  def getKeys(): List[MultiHash] = 
+    this.synchronized {
+      val keys = new ListBuffer[MultiHash]
+      val iter = db.newIterator
+      iter.seekToFirst
+      while (iter.isValid) {
+        MultiHash.fromBytes(iter.key).foreach {key => keys += key}
+        iter.next
+      }
+      keys.toList
     }
-    keys.toList
-  }
+  
 }
 

--- a/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/RocksDatastore.scala
@@ -19,7 +19,7 @@ class RocksDatastore(path: String)
     Option(db.get(key.bytes))
   
   def removeData(key: MultiHash) {
-    // XXX Implement me!
+    db.remove(key.bytes)
   }
 }
 


### PR DESCRIPTION
#61 #26

Implements a PersistentDatastore which acts a write-through cache to Dynamo:
data are disk-persisted in a local rocks datastore until they are written through to Dynamo by a background thread.

Further refinements:
- more complete error handling
- perhaps chattier logs to help with debugging
