### PR TITLE
Rename root sbt project to make intellij happy

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -153,13 +153,7 @@ object MediachainBuild extends Build {
     initialCommands in (Test, console) := "ammonite.repl.Main.run(\"" + predef + "\")"
   )).dependsOn(orientdb_migrations)
     .dependsOn(core)
-
-
-  // for separating work on CircleCI containers (try to keep these balanced)
-  lazy val circle_1 = project
-    .aggregate(translation_engine, rpc)
-  lazy val circle_2 = project
-    .aggregate(core, l_space)
+  
 
   // aggregate means commands will cascade to the subprojects
   // dependsOn means classes will be available

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -157,7 +157,7 @@ object MediachainBuild extends Build {
 
   // aggregate means commands will cascade to the subprojects
   // dependsOn means classes will be available
-  lazy val root = (project in file("."))
+  lazy val mediachain = (project in file("."))
     .aggregate(core, l_space,
       translation_engine, rpc, transactor, protocol)
 }


### PR DESCRIPTION
IntelliJ's sbt indexer gets confused if the root project is named "root", because it conflicts with the root project of the scala-multihash dependency, which is also named "root".  This doesn't affect compilation by sbt itself, but is annoying when editing, because IntelliJ can't find the multihash project and flags it as missing.

This renames the root project to "mediachain", which causes everything to index correctly.

Also removes the "circle_1" and "circle_2" subprojects, since we're using Travis now.
