### PR TITLE
Scalacheck generators for blockchain + data objects

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -1,18 +1,20 @@
 package io.mediachain.protocol
 
-import io.mediachain.multihash.MultiHash
-
 
 object Datastore {
   import io.mediachain.multihash.MultiHash
   import io.mediachain.protocol.CborSerialization._
   import io.mediachain.protocol.Transactor.{ArtefactChainReference, ChainReference, EntityChainReference}
   import io.mediachain.util.cbor.CborAST._
+  import scala.util.Try
 
   // Datastore interface
   trait Datastore {
     def get(ref: Reference): Option[DataObject]
     def put(obj: DataObject): Reference
+
+    def getAs[T <: DataObject](ref: Reference): Option[T] =
+      get(ref).flatMap(obj => Try(obj.asInstanceOf[T]).toOption)
   }
 
   class DatastoreException(what: String) extends RuntimeException(what)

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -1,5 +1,6 @@
 package io.mediachain.protocol
 
+import io.mediachain.multihash.MultiHash
 
 
 object Datastore {
@@ -36,6 +37,12 @@ object Datastore {
       CMap.withStringKeys("@link" -> CBytes(multihash.bytes))
   }
 
+  object MultihashReference {
+    def forDataObject(dataObject: DataObject): MultihashReference =
+      MultihashReference(
+        MultiHash.hashWithSHA256(dataObject.toCborBytes)
+      )
+  }
 
   // Canonical records: Entities and Artefacts
   sealed abstract class CanonicalRecord extends Record {

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -74,6 +74,7 @@ object Datastore {
 
   // Chain cells
   sealed abstract class ChainCell extends Record {
+    def ref: Reference
     def chain: Option[Reference]
     def cons(chain: Option[Reference]): ChainCell
   }
@@ -83,6 +84,8 @@ object Datastore {
     val chain: Option[Reference],
     val meta: Map[String, CValue]
   ) extends ChainCell {
+    val ref = entity
+
     override def cons(xchain: Option[Reference]): ChainCell =
       EntityChainCell(entity, xchain, meta)
 
@@ -111,6 +114,8 @@ object Datastore {
     val chain: Option[Reference],
     val meta: Map[String, CValue]
   ) extends ChainCell {
+    val ref = artefact
+
     override def cons(xchain: Option[Reference]): ChainCell =
       ArtefactChainCell(artefact, xchain, meta)
     

--- a/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
@@ -94,7 +94,7 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
     fromCbor(cbor) must beRightXor { obj: EntityChainCell =>
       obj must matchEntityChainCell(c)
     }
-  }.setArbitrary(Arbitrary(genEntityChainCell))
+  }.setArbitrary(abEntityChainCell)
 
   def roundTripEntityUpdateCell = prop { c: EntityUpdateCell =>
     val cbor = c.toCbor
@@ -217,10 +217,10 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
         obj must haveClass[ArtefactChainCell]
       }
     }.setGen(Gen.oneOf(
-        genArtefactReferenceCell,
-        genArtefactUpdateCell,
-        genArtefactOwnershipCell,
-        genArtefactDerivationCell,
-        genArtefactCreationCell
+        genArtefactReferenceCell(),
+        genArtefactUpdateCell(),
+        genArtefactOwnershipCell(),
+        genArtefactDerivationCell(),
+        genArtefactCreationCell()
       ))
 }

--- a/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
@@ -218,10 +218,10 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
         obj must haveClass[ArtefactChainCell]
       }
     }.setGen(Gen.oneOf(
-        genArtefactReferenceCell(),
-        genArtefactUpdateCell(),
-        genArtefactOwnershipCell(),
-        genArtefactDerivationCell(),
-        genArtefactCreationCell()
+        genArtefactReferenceCell,
+        genArtefactUpdateCell,
+        genArtefactOwnershipCell,
+        genArtefactDerivationCell,
+        genArtefactCreationCell
       ))
 }

--- a/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
@@ -10,7 +10,7 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
   import io.mediachain.protocol.Datastore._
   import io.mediachain.util.cbor.CborAST._
   import org.scalacheck.{Arbitrary, Gen}
-  import org.scalacheck.Test.Parameters
+  import org.specs2.scalacheck.Parameters
   import org.specs2.matcher.Matcher
 
   def is =
@@ -38,10 +38,11 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
       """
 
 
-  implicit val scalaCheckParams = Parameters.default
-    .withMinSuccessfulTests(10) // # of tests needed to pass before marking as success
-    .withMaxSize(5) // # of items to generate for containers (lists, etc)
-
+  implicit val scalaCheckParams =
+    Parameters(
+      minTestsOk = 10, // # of tests needed to pass before marking as success
+      maxSize = 5 // # of items to generate for containers (lists, etc)
+    )
 
   def matchTypeName(typeName: MediachainType): Matcher[CValue] =
     beLike {

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -33,48 +33,81 @@ object DataObjectGenerators {
     meta <- genMeta
   } yield Artefact(meta)
 
-  val genEntityChainCell = for {
-    entity <- genReference
-    chain <- genReference
+  def genReferenceFor(canonicalGen: Gen[CanonicalRecord]): Gen[Reference] =
+    for {
+      canonical <- canonicalGen
+    } yield MultihashReference.forDataObject(canonical)
+
+
+  def genEntityChainCell(
+    entityGen: Gen[Entity] = genEntity,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    entity <- genReferenceFor(entityGen)
+    chain <- chainGen
     meta <- genMeta
   } yield EntityChainCell(entity, Some(chain), meta)
 
-  val genArtefactChainCell = for {
-    artefact <- genReference
-    chain <- genReference
+  def genArtefactChainCell(
+    artefactGen: Gen[Artefact] = genArtefact,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    artefact <- genReferenceFor(artefactGen)
+    chain <- chainGen
     meta <- genMeta
   } yield ArtefactChainCell(artefact, Some(chain), meta)
 
-  val genEntityUpdateCell = for {
-    base <- genEntityChainCell
+  def genEntityUpdateCell(
+    entityGen: Gen[Entity] = genEntity,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    base <- genEntityChainCell(entityGen, chainGen)
   } yield EntityUpdateCell(base.entity, base.chain, base.meta)
 
-  val genEntityLinkCell = for {
-    base <- genEntityChainCell
+  def genEntityLinkCell(
+    entityGen: Gen[Entity] = genEntity,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    base <- genEntityChainCell(entityGen, chainGen)
     entityLink <- genReference
   } yield EntityLinkCell(base.entity, base.chain, base.meta, entityLink)
 
-  val genArtefactUpdateCell = for {
-    base <- genArtefactChainCell
+  def genArtefactUpdateCell(
+    artefactGen: Gen[Artefact] = genArtefact,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    base <- genArtefactChainCell(artefactGen, chainGen)
   } yield ArtefactUpdateCell(base.artefact, base.chain, base.meta)
 
-  val genArtefactCreationCell = for {
-    base <- genArtefactChainCell
+  def genArtefactCreationCell(
+    artefactGen: Gen[Artefact] = genArtefact,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- genReference
   } yield ArtefactCreationCell(base.artefact, base.chain, base.meta, entity)
 
-  val genArtefactDerivationCell = for {
-    base <- genArtefactChainCell
+  def genArtefactDerivationCell(
+    artefactGen: Gen[Artefact] = genArtefact,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    base <- genArtefactChainCell(artefactGen, chainGen)
     artefactOrigin <- genReference
   } yield ArtefactDerivationCell(base.artefact, base.chain, base.meta, artefactOrigin)
 
-  val genArtefactOwnershipCell = for {
-    base <- genArtefactChainCell
+  def genArtefactOwnershipCell(
+    artefactGen: Gen[Artefact] = genArtefact,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- genReference
   } yield ArtefactOwnershipCell(base.artefact, base.chain, base.meta, entity)
 
-  val genArtefactReferenceCell = for {
-    base <- genArtefactChainCell
+  def genArtefactReferenceCell(
+    artefactGen: Gen[Artefact] = genArtefact,
+    chainGen: Gen[Reference] = genReference
+  ) = for {
+    base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- genReference
   } yield ArtefactReferenceCell(base.artefact, base.chain, base.meta, entity)
 
@@ -99,15 +132,15 @@ object DataObjectGenerators {
 
   implicit def abEntity: Arbitrary[Entity] = Arbitrary(genEntity)
   implicit def abArtefact: Arbitrary[Artefact] = Arbitrary(genArtefact)
-  implicit def abEntityChainCell: Arbitrary[EntityChainCell] = Arbitrary(genEntityChainCell)
-  implicit def abArtefactChainCell: Arbitrary[ArtefactChainCell] = Arbitrary(genArtefactChainCell)
-  implicit def abEntityUpdateCell: Arbitrary[EntityUpdateCell] = Arbitrary(genEntityUpdateCell)
-  implicit def abEntityLinkCell: Arbitrary[EntityLinkCell] = Arbitrary(genEntityLinkCell)
-  implicit def abArtefactUpdateCell: Arbitrary[ArtefactUpdateCell] = Arbitrary(genArtefactUpdateCell)
-  implicit def abArtefactCreationCell: Arbitrary[ArtefactCreationCell] = Arbitrary(genArtefactCreationCell)
-  implicit def abArtefactDerivationCell: Arbitrary[ArtefactDerivationCell] = Arbitrary(genArtefactDerivationCell)
-  implicit def abArtefactOwnershipCell: Arbitrary[ArtefactOwnershipCell] = Arbitrary(genArtefactOwnershipCell)
-  implicit def abArtefactReferenceCell: Arbitrary[ArtefactReferenceCell] = Arbitrary(genArtefactReferenceCell)
+  implicit def abEntityChainCell: Arbitrary[EntityChainCell] = Arbitrary(genEntityChainCell())
+  implicit def abArtefactChainCell: Arbitrary[ArtefactChainCell] = Arbitrary(genArtefactChainCell())
+  implicit def abEntityUpdateCell: Arbitrary[EntityUpdateCell] = Arbitrary(genEntityUpdateCell())
+  implicit def abEntityLinkCell: Arbitrary[EntityLinkCell] = Arbitrary(genEntityLinkCell())
+  implicit def abArtefactUpdateCell: Arbitrary[ArtefactUpdateCell] = Arbitrary(genArtefactUpdateCell())
+  implicit def abArtefactCreationCell: Arbitrary[ArtefactCreationCell] = Arbitrary(genArtefactCreationCell())
+  implicit def abArtefactDerivationCell: Arbitrary[ArtefactDerivationCell] = Arbitrary(genArtefactDerivationCell())
+  implicit def abArtefactOwnershipCell: Arbitrary[ArtefactOwnershipCell] = Arbitrary(genArtefactOwnershipCell())
+  implicit def abArtefactReferenceCell: Arbitrary[ArtefactReferenceCell] = Arbitrary(genArtefactReferenceCell())
   implicit def abCanonicalEntry: Arbitrary[CanonicalEntry] = Arbitrary(genCanonicalEntry)
   implicit def abChainEntry: Arbitrary[ChainEntry] = Arbitrary(genChainEntry)
   implicit def abJournalBlock: Arbitrary[JournalBlock] = Arbitrary(genJournalBlock)

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -13,23 +13,23 @@ object DataObjectGenerators {
   import io.mediachain.util.cbor.CborAST._
   import io.mediachain.util.cbor.CValueGenerators._
 
-  val stringMetaGens: List[Gen[(String, CValue)]] = (1 to 25).toList.map { _ =>
+  val genStringMetas: List[Gen[(String, CValue)]] = (1 to 25).toList.map { _ =>
     for {
       key <- Gen.alphaStr
       value <- genCPrimitive
     } yield (key, value)
   }
 
-  val dateMetaGen: Gen[(String, CString)] = for {
+  val genDateMeta: Gen[(String, CString)] = for {
     date <- arbitrary[Date]
   } yield ("date", CString(date.toString))
 
-  val authorMetaGen: Gen[(String, CString)] = for {
-    author <- arbitrary[String] // TODO: make this a MultiHash etc
+  val genAuthorMeta: Gen[(String, CString)] = for {
+    author <- arbitrary[String] // TODO: make this a real special type
   } yield ("author", CString(author))
 
   val genMeta: Gen[Map[String, CValue]] = for {
-    meta <- Gen.someOf[(String, CValue)](authorMetaGen, dateMetaGen, stringMetaGens:_*)
+    meta <- Gen.someOf[(String, CValue)](genAuthorMeta, genDateMeta, genStringMetas:_*)
   } yield meta.toMap
 
   val genReference: Gen[Reference] = for {

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -26,7 +26,7 @@ object DataObjectGenerators {
   )
 
   val genOptionalReference: Gen[Option[Reference]] =
-    Gen.oneOf(Gen.const(None), genReference.map(r => Some(r)))
+    Gen.option(genReference)
 
   val genNilReference: Gen[Option[Reference]] = Gen.const(None)
 
@@ -72,10 +72,11 @@ object DataObjectGenerators {
 
   def genEntityLinkCell(
     entityGen: Gen[Entity] = genEntity,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference,
+    entityLinkGen: Gen[Reference] = genReference
   ) = for {
     base <- genEntityChainCell(entityGen, chainGen)
-    entityLink <- genReference
+    entityLink <- entityLinkGen
   } yield EntityLinkCell(base.entity, base.chain, base.meta, entityLink)
 
   def genArtefactUpdateCell(
@@ -87,34 +88,38 @@ object DataObjectGenerators {
 
   def genArtefactCreationCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference,
+    entityGen: Gen[Reference] = genReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
-    entity <- genReference
+    entity <- entityGen
   } yield ArtefactCreationCell(base.artefact, base.chain, base.meta, entity)
 
   def genArtefactDerivationCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference,
+    artefactOriginGen: Gen[Reference] = genReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
-    artefactOrigin <- genReference
+    artefactOrigin <- artefactOriginGen
   } yield ArtefactDerivationCell(base.artefact, base.chain, base.meta, artefactOrigin)
 
   def genArtefactOwnershipCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference,
+    entityGen: Gen[Reference] = genReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
-    entity <- genReference
+    entity <- entityGen
   } yield ArtefactOwnershipCell(base.artefact, base.chain, base.meta, entity)
 
   def genArtefactReferenceCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference,
+    entityGen: Gen[Reference] = genReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
-    entity <- genReference
+    entity <- entityGen
   } yield ArtefactReferenceCell(base.artefact, base.chain, base.meta, entity)
 
   val genCanonicalEntry = for {

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -43,11 +43,11 @@ object DataObjectGenerators {
 
   val genNilReference: Gen[Option[Reference]] = Gen.const(None)
 
-  val genEntity = for {
+  val genEntity: Gen[Entity] = for {
     meta <- genMeta
   } yield Entity(meta)
 
-  val genArtefact = for {
+  val genArtefact: Gen[Artefact] = for {
     meta <- genMeta
   } yield Artefact(meta)
 
@@ -57,81 +57,90 @@ object DataObjectGenerators {
     } yield MultihashReference.forDataObject(canonical)
 
   def genEntityChainCell(
-    entityGen: Gen[Entity] = genEntity,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    entityGen: Gen[Entity],
+    chainGen: Gen[Option[Reference]]
   ) = for {
     entity <- genReferenceFor(entityGen)
     chain <- chainGen
     meta <- genMeta
   } yield EntityChainCell(entity, chain, meta)
+  val genEntityChainCell: Gen[EntityChainCell] = genEntityChainCell(genEntity, genOptionalReference)
 
   def genArtefactChainCell(
-    artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    artefactGen: Gen[Artefact],
+    chainGen: Gen[Option[Reference]]
   ) = for {
     artefact <- genReferenceFor(artefactGen)
     chain <- chainGen
     meta <- genMeta
   } yield ArtefactChainCell(artefact, chain, meta)
+  val genArtefactChainCell: Gen[ArtefactChainCell] = genArtefactChainCell(genArtefact, genOptionalReference)
 
   def genEntityUpdateCell(
-    entityGen: Gen[Entity] = genEntity,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    entityGen: Gen[Entity],
+    chainGen: Gen[Option[Reference]]
   ) = for {
     base <- genEntityChainCell(entityGen, chainGen)
   } yield EntityUpdateCell(base.entity, base.chain, base.meta)
+  val genEntityUpdateCell: Gen[EntityUpdateCell] = genEntityUpdateCell(genEntity, genOptionalReference)
 
   def genEntityLinkCell(
-    entityGen: Gen[Entity] = genEntity,
-    chainGen: Gen[Option[Reference]] = genOptionalReference,
-    entityLinkGen: Gen[Reference] = genReference
+    entityGen: Gen[Entity],
+    chainGen: Gen[Option[Reference]],
+    entityLinkGen: Gen[Reference]
   ) = for {
     base <- genEntityChainCell(entityGen, chainGen)
     entityLink <- entityLinkGen
   } yield EntityLinkCell(base.entity, base.chain, base.meta, entityLink)
+  val genEntityLinkCell: Gen[EntityLinkCell] = genEntityLinkCell(genEntity, genOptionalReference, genReference)
 
   def genArtefactUpdateCell(
-    artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference
+    artefactGen: Gen[Artefact],
+    chainGen: Gen[Option[Reference]]
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
   } yield ArtefactUpdateCell(base.artefact, base.chain, base.meta)
+  val genArtefactUpdateCell: Gen[ArtefactUpdateCell] = genArtefactUpdateCell(genArtefact, genOptionalReference)
 
   def genArtefactCreationCell(
-    artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference,
-    entityGen: Gen[Reference] = genReference
+    artefactGen: Gen[Artefact],
+    chainGen: Gen[Option[Reference]],
+    entityGen: Gen[Reference]
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- entityGen
   } yield ArtefactCreationCell(base.artefact, base.chain, base.meta, entity)
+  val genArtefactCreationCell: Gen[ArtefactCreationCell] = genArtefactCreationCell(genArtefact, genOptionalReference, genReference)
 
   def genArtefactDerivationCell(
-    artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference,
-    artefactOriginGen: Gen[Reference] = genReference
+    artefactGen: Gen[Artefact],
+    chainGen: Gen[Option[Reference]],
+    artefactOriginGen: Gen[Reference]
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     artefactOrigin <- artefactOriginGen
   } yield ArtefactDerivationCell(base.artefact, base.chain, base.meta, artefactOrigin)
+  val genArtefactDerivationCell: Gen[ArtefactDerivationCell] = genArtefactDerivationCell(genArtefact, genOptionalReference, genReference)
 
   def genArtefactOwnershipCell(
-    artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference,
-    entityGen: Gen[Reference] = genReference
+    artefactGen: Gen[Artefact],
+    chainGen: Gen[Option[Reference]],
+    entityGen: Gen[Reference]
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- entityGen
   } yield ArtefactOwnershipCell(base.artefact, base.chain, base.meta, entity)
+  val genArtefactOwnershipCell: Gen[ArtefactOwnershipCell] = genArtefactOwnershipCell(genArtefact, genOptionalReference, genReference)
 
   def genArtefactReferenceCell(
-    artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Option[Reference]] = genOptionalReference,
-    entityGen: Gen[Reference] = genReference
+    artefactGen: Gen[Artefact],
+    chainGen: Gen[Option[Reference]],
+    entityGen: Gen[Reference]
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- entityGen
   } yield ArtefactReferenceCell(base.artefact, base.chain, base.meta, entity)
+  val genArtefactReferenceCell: Gen[ArtefactReferenceCell] = genArtefactReferenceCell(genArtefact, genOptionalReference, genReference)
 
   val genCanonicalEntry = for {
     index <- arbitrary[BigInt]
@@ -154,15 +163,15 @@ object DataObjectGenerators {
 
   implicit def abEntity: Arbitrary[Entity] = Arbitrary(genEntity)
   implicit def abArtefact: Arbitrary[Artefact] = Arbitrary(genArtefact)
-  implicit def abEntityChainCell: Arbitrary[EntityChainCell] = Arbitrary(genEntityChainCell())
-  implicit def abArtefactChainCell: Arbitrary[ArtefactChainCell] = Arbitrary(genArtefactChainCell())
-  implicit def abEntityUpdateCell: Arbitrary[EntityUpdateCell] = Arbitrary(genEntityUpdateCell())
-  implicit def abEntityLinkCell: Arbitrary[EntityLinkCell] = Arbitrary(genEntityLinkCell())
-  implicit def abArtefactUpdateCell: Arbitrary[ArtefactUpdateCell] = Arbitrary(genArtefactUpdateCell())
-  implicit def abArtefactCreationCell: Arbitrary[ArtefactCreationCell] = Arbitrary(genArtefactCreationCell())
-  implicit def abArtefactDerivationCell: Arbitrary[ArtefactDerivationCell] = Arbitrary(genArtefactDerivationCell())
-  implicit def abArtefactOwnershipCell: Arbitrary[ArtefactOwnershipCell] = Arbitrary(genArtefactOwnershipCell())
-  implicit def abArtefactReferenceCell: Arbitrary[ArtefactReferenceCell] = Arbitrary(genArtefactReferenceCell())
+  implicit def abEntityChainCell: Arbitrary[EntityChainCell] = Arbitrary(genEntityChainCell)
+  implicit def abArtefactChainCell: Arbitrary[ArtefactChainCell] = Arbitrary(genArtefactChainCell)
+  implicit def abEntityUpdateCell: Arbitrary[EntityUpdateCell] = Arbitrary(genEntityUpdateCell)
+  implicit def abEntityLinkCell: Arbitrary[EntityLinkCell] = Arbitrary(genEntityLinkCell)
+  implicit def abArtefactUpdateCell: Arbitrary[ArtefactUpdateCell] = Arbitrary(genArtefactUpdateCell)
+  implicit def abArtefactCreationCell: Arbitrary[ArtefactCreationCell] = Arbitrary(genArtefactCreationCell)
+  implicit def abArtefactDerivationCell: Arbitrary[ArtefactDerivationCell] = Arbitrary(genArtefactDerivationCell)
+  implicit def abArtefactOwnershipCell: Arbitrary[ArtefactOwnershipCell] = Arbitrary(genArtefactOwnershipCell)
+  implicit def abArtefactReferenceCell: Arbitrary[ArtefactReferenceCell] = Arbitrary(genArtefactReferenceCell)
   implicit def abCanonicalEntry: Arbitrary[CanonicalEntry] = Arbitrary(genCanonicalEntry)
   implicit def abChainEntry: Arbitrary[ChainEntry] = Arbitrary(genChainEntry)
   implicit def abJournalBlock: Arbitrary[JournalBlock] = Arbitrary(genJournalBlock)

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -25,6 +25,12 @@ object DataObjectGenerators {
     MultiHash.hashWithSHA256(str.getBytes(StandardCharsets.UTF_8))
   )
 
+  val genOptionalReference: Gen[Option[Reference]] =
+    Gen.oneOf(Gen.const(None), genReference.map(r => Some(r)))
+
+  val genNilReference: Gen[Option[Reference]] = Gen.const(None)
+
+
   val genEntity = for {
     meta <- genMeta
   } yield Entity(meta)
@@ -41,32 +47,32 @@ object DataObjectGenerators {
 
   def genEntityChainCell(
     entityGen: Gen[Entity] = genEntity,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     entity <- genReferenceFor(entityGen)
     chain <- chainGen
     meta <- genMeta
-  } yield EntityChainCell(entity, Some(chain), meta)
+  } yield EntityChainCell(entity, chain, meta)
 
   def genArtefactChainCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     artefact <- genReferenceFor(artefactGen)
     chain <- chainGen
     meta <- genMeta
-  } yield ArtefactChainCell(artefact, Some(chain), meta)
+  } yield ArtefactChainCell(artefact, chain, meta)
 
   def genEntityUpdateCell(
     entityGen: Gen[Entity] = genEntity,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     base <- genEntityChainCell(entityGen, chainGen)
   } yield EntityUpdateCell(base.entity, base.chain, base.meta)
 
   def genEntityLinkCell(
     entityGen: Gen[Entity] = genEntity,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     base <- genEntityChainCell(entityGen, chainGen)
     entityLink <- genReference
@@ -74,14 +80,14 @@ object DataObjectGenerators {
 
   def genArtefactUpdateCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
   } yield ArtefactUpdateCell(base.artefact, base.chain, base.meta)
 
   def genArtefactCreationCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- genReference
@@ -89,7 +95,7 @@ object DataObjectGenerators {
 
   def genArtefactDerivationCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     artefactOrigin <- genReference
@@ -97,7 +103,7 @@ object DataObjectGenerators {
 
   def genArtefactOwnershipCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- genReference
@@ -105,7 +111,7 @@ object DataObjectGenerators {
 
   def genArtefactReferenceCell(
     artefactGen: Gen[Artefact] = genArtefact,
-    chainGen: Gen[Reference] = genReference
+    chainGen: Gen[Option[Reference]] = genOptionalReference
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- genReference

--- a/protocol/src/test/scala/io/mediachain/protocol/InMemoryDatastore.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/InMemoryDatastore.scala
@@ -1,0 +1,23 @@
+package io.mediachain.protocol
+
+import io.mediachain.protocol.Datastore._
+
+class InMemoryDatastore extends Datastore {
+  import collection.mutable.{Map => MMap}
+
+  def copy: InMemoryDatastore = {
+    val other = new InMemoryDatastore
+    store.foreach(t => other.store.put(t._1, t._2))
+    other
+  }
+
+  val store: MMap[Reference, DataObject] = MMap()
+
+  override def get(ref: Reference): Option[DataObject] = store.get(ref)
+
+  override def put(obj: DataObject): Reference = {
+    val ref = MultihashReference.forDataObject(obj)
+    store.put(ref, obj)
+    ref
+  }
+}

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -130,7 +130,7 @@ object JournalBlockGenerators {
       canonicals.zipWithIndex.map { pair =>
         val (c, i) = pair
         val index = startIndex + i
-        CanonicalEntry(i, MultihashReference.forDataObject(c))
+        CanonicalEntry(index, MultihashReference.forDataObject(c))
     }
 
     val chainStartIndex = startIndex + canonicalEntries.length

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -7,7 +7,42 @@ object JournalBlockGenerators {
 
 
   /**
+    * Generate a chain cell that references the given `CanonicalRecord`
+    *
+    * @param canonical either an `Entity` or `Artefact` to generate a cell for
+    * @return depending on the type of `CanonicalRecord` given, either a
+    *         subtype of `EntityChainCell` or `EntityArtefactCell`.
+    *         Note that the `chain` field of the returned cell will be
+    *         set to `None`
+    *
+    */
+  def genCellFor(canonical: CanonicalRecord): Gen[ChainCell] = {
+    canonical match {
+      case e: Entity => {
+        val entityGen = Gen.const(e)
+        Gen.oneOf(
+          genEntityUpdateCell(entityGen, genNilReference),
+          genEntityLinkCell(entityGen, genNilReference)
+        )
+      }
+
+      case a: Artefact => {
+        val artefactGen = Gen.const(a)
+        Gen.oneOf(
+          genArtefactUpdateCell(artefactGen, genNilReference),
+          genArtefactCreationCell(artefactGen, genNilReference),
+          genArtefactDerivationCell(artefactGen, genNilReference),
+          genArtefactOwnershipCell(artefactGen, genNilReference),
+          genArtefactReferenceCell(artefactGen, genNilReference)
+        )
+      }
+    }
+  }
+
+
+  /**
     * Generate a chain of cells for the given `CanonicalRecord`.
+    *
     * @param length number of cells to generate
     * @param canonical the `ref` for each cell.  The type of `CanonicalRecord`
     *                  given will determine whether `EntityChainCell`s or
@@ -19,26 +54,7 @@ object JournalBlockGenerators {
     *         `None`.
     */
   def genChain(length: Int, canonical: CanonicalRecord): Gen[List[ChainCell]] = {
-    val cellGen: Gen[ChainCell] = canonical match {
-      case e: Entity => {
-        val entityGen = Gen.const(e)
-        Gen.oneOf(
-          genEntityUpdateCell(entityGen),
-          genEntityLinkCell(entityGen)
-        )
-      }
-
-      case a: Artefact => {
-        val artefactGen = Gen.const(a)
-        Gen.oneOf(
-          genArtefactUpdateCell(artefactGen),
-          genArtefactCreationCell(artefactGen),
-          genArtefactDerivationCell(artefactGen),
-          genArtefactOwnershipCell(artefactGen),
-          genArtefactReferenceCell(artefactGen)
-        )
-      }
-    }
+    val cellGen: Gen[ChainCell] = genCellFor(canonical)
 
     for {
       cells <- Gen.listOfN(length, cellGen)

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -7,64 +7,164 @@ object JournalBlockGenerators {
 
 
   /**
-    * Generate a chain cell that references the given `CanonicalRecord`
+    * Make a generator that returns a chain cell for the given `CanonicalRecord`
     *
     * @param canonical either an `Entity` or `Artefact` to generate a cell for
-    * @return depending on the type of `CanonicalRecord` given, either a
-    *         subtype of `EntityChainCell` or `EntityArtefactCell`.
-    *         Note that the `chain` field of the returned cell will be
+    * @param entityReferences a list of references to Entities to choose from
+    *                         when constructing relationships.  If empty,
+    *                         only generic `EntityUpdateCell`s or
+    *                         `ArtefactUpdateCell`s will be generated.
+    * @return depending on the type of `CanonicalRecord` given, a generator for
+    *         either a subtype of `EntityChainCell` or `EntityArtefactCell`.
+    *         Note that the `chain` field of the generated cell will be
     *         set to `None`
     *
     */
-  def genCellFor(canonical: CanonicalRecord): Gen[ChainCell] = {
+  def genCellFor(canonical: CanonicalRecord,
+    entityReferences: List[Reference],
+    artefactReferences: List[Reference])
+  : Gen[ChainCell] =
     canonical match {
-      case e: Entity => {
-        val entityGen = Gen.const(e)
-        Gen.oneOf(
-          genEntityUpdateCell(entityGen, genNilReference),
-          genEntityLinkCell(entityGen, genNilReference)
-        )
-      }
+      case e: Entity => genEntityCellFor(e, entityReferences)
+      case a: Artefact => genArtefactCellFor(a, entityReferences, artefactReferences)
+    }
 
-      case a: Artefact => {
-        val artefactGen = Gen.const(a)
-        Gen.oneOf(
-          genArtefactUpdateCell(artefactGen, genNilReference),
-          genArtefactCreationCell(artefactGen, genNilReference),
-          genArtefactDerivationCell(artefactGen, genNilReference),
-          genArtefactOwnershipCell(artefactGen, genNilReference),
-          genArtefactReferenceCell(artefactGen, genNilReference)
-        )
-      }
+
+  /**
+    * Make a generator that returns an `EntityChainCell` for the given `Entity`
+    * @param entity the `Entity` to generate a cell for
+    * @param entityReferences a list of references to Entities to choose from
+    *                         when constructing relationships.  If empty,
+    *                         only generic `EntityUpdateCell`s will be generated.
+    * @return a generator for a subtype of `EntityChainCell`. Note that the
+    *         `chain` field of the generated cell will be set to `None`
+    */
+  def genEntityCellFor(entity: Entity, entityReferences: List[Reference])
+  : Gen[EntityChainCell] = {
+    val entityGen = Gen.const(entity)
+    if (entityReferences.isEmpty) {
+      genEntityUpdateCell(entityGen, genNilReference)
+    } else {
+      Gen.oneOf(
+        genEntityUpdateCell(entityGen, genNilReference),
+        genEntityLinkCell(entityGen, genNilReference, Gen.oneOf(entityReferences))
+      )
+    }
+  }
+
+  /**
+    * Make a generator that returns an `ArtefactChainCell` for the given `Artefact`
+    * @param artefact the `Artefact` to generate a cell for
+    * @param entityReferences a list of references to Entities to choose from
+    *                         when constructing relationships.  If empty,
+    *                         only generic `ArtefactUpdateCell`s will be generated.
+    * @param artefactReferences a list of references to Artefacts to choose from
+    *                         when constructing relationships.  If empty,
+    *                         only generic `ArtefactUpdateCell`s will be generated.
+    * @return a generator for a subtype of `ArtefactChainCell`. Note that the
+    *         `chain` field of the generated cell will be set to `None`
+    */
+  def genArtefactCellFor(
+    artefact: Artefact,
+    entityReferences: List[Reference],
+    artefactReferences: List[Reference]
+  ): Gen[ArtefactChainCell] = {
+    val artefactGen = Gen.const(artefact)
+    if (entityReferences.isEmpty || artefactReferences.isEmpty) {
+      genArtefactUpdateCell(artefactGen, genNilReference)
+    } else {
+      Gen.oneOf(
+        genArtefactUpdateCell(artefactGen, genNilReference),
+        genArtefactCreationCell(artefactGen, genNilReference, Gen.oneOf(entityReferences)),
+        genArtefactDerivationCell(artefactGen, genNilReference, Gen.oneOf(artefactReferences)),
+        genArtefactOwnershipCell(artefactGen, genNilReference, Gen.oneOf(entityReferences)),
+        genArtefactReferenceCell(artefactGen, genNilReference, Gen.oneOf(entityReferences))
+      )
     }
   }
 
 
+  def consChainCells(cells: List[ChainCell]): List[ChainCell] = {
+    import collection.mutable.{Map => MMap, MutableList => MList}
+    val chainHeads: MMap[Reference, ChainCell] = MMap()
+    val consed: MList[ChainCell] = MList()
+
+    cells.foreach { c =>
+      val canonicalRef = c match {
+        case e: EntityChainCell => e.entity
+        case a: ArtefactChainCell => a.artefact
+      }
+
+      val head = chainHeads.get(canonicalRef)
+        .map(h => MultihashReference.forDataObject(h))
+
+      val consedCell = c.cons(head)
+      chainHeads.put(canonicalRef, consedCell)
+      consed += consedCell
+    }
+
+    consed.toList
+  }
+
+
+  type MockMediachain = (Map[MultihashReference, DataObject], List[JournalBlock])
+
   /**
-    * Generate a chain of cells for the given `CanonicalRecord`.
+    * Generates a mock `Datastore` (as a `Map[MultihashReference, DataObject]`)
+    * and a journal, (as a `List[JournalBlock]`).
     *
-    * @param length number of cells to generate
-    * @param canonical the `ref` for each cell.  The type of `CanonicalRecord`
-    *                  given will determine whether `EntityChainCell`s or
-    *                  `ArtefactChainCell`s are generated
-    * @return - a generator that returns a `List[ChainCell]` of the given
-    *         `length`, whose cells are consed together so that the head
-    *         of the list has a `chain` that points to the next cell, and
-    *         so on. The last cell in the list will have a `chain` value of
-    *         `None`.
+    * @param length number of `JournalBlock`s to generate
+    * @param blockSize number of `JournalEntries` per block
+    * @return a tuple containing the mock datastore and the list of journal
+    *         blocks.
     */
-  def genChain(length: Int, canonical: CanonicalRecord): Gen[List[ChainCell]] = {
-    val cellGen: Gen[ChainCell] = genCellFor(canonical)
+
+  def genMediachain(length: Int, blockSize: Int)
+  : Gen[MockMediachain] = {
+    // the idea here is to generate all the data objects up front, then map
+    // them each into a `JournalEntry` and bundle those up into blocks until
+    // we have enough.
+
+    val numDataObjects = length * blockSize
+
+    // generate ~ twice as many chain cells as canonical entries
+    val numCanonicals = (numDataObjects * 0.3).toInt
+    val numChainCells = numDataObjects - numCanonicals
+
+    // generate ~ 3x as many artefacts as entities
+    val numEntities = (numCanonicals * 0.25).toInt
+    val numArtefacts = numCanonicals - numEntities
 
     for {
-      cells <- Gen.listOfN(length, cellGen)
-    } yield {
-      cells.foldLeft(List[ChainCell]()) { (consedCells, cell) =>
-        val headRef = consedCells.headOption
-          .map(c => MultihashReference.forDataObject(c))
+      entities <- Gen.listOfN(numEntities, genEntity)
+      artefacts <- Gen.listOfN(numArtefacts, genArtefact)
 
-        cell.cons(headRef) :: consedCells
-      }
+      canonicals = entities ++ artefacts
+      entityReferences = entities.map(e => MultihashReference.forDataObject(e))
+      artefactReferences = artefacts.map(a => MultihashReference.forDataObject(a))
+
+      cellGen = Gen.oneOf(canonicals)
+        .flatMap(genCellFor(_, entityReferences, artefactReferences))
+
+      chainCells <- Gen.listOfN(numChainCells, cellGen)
+      consed = consChainCells(chainCells)
+    } yield {
+
+      ???
     }
+  }
+
+
+  private def toJournalEntries(canonicals: List[CanonicalRecord], chainCells: List[ChainCell]):
+    List[JournalEntry] = {
+    import collection.mutable.{MutableList => MList}
+    val mCanonicals = MList(canonicals)
+    val mCells = MList(chainCells)
+
+
+    val entries: MList[JournalEntry] = MList()
+
+
+    ???
   }
 }

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -1,0 +1,54 @@
+package io.mediachain.protocol
+
+object JournalBlockGenerators {
+  import io.mediachain.protocol.Datastore._
+  import org.scalacheck._
+  import DataObjectGenerators._
+
+
+  /**
+    * Generate a chain of cells for the given `CanonicalRecord`.
+    * @param length number of cells to generate
+    * @param canonical the `ref` for each cell.  The type of `CanonicalRecord`
+    *                  given will determine whether `EntityChainCell`s or
+    *                  `ArtefactChainCell`s are generated
+    * @return - a generator that returns a `List[ChainCell]` of the given
+    *         `length`, whose cells are consed together so that the head
+    *         of the list has a `chain` that points to the next cell, and
+    *         so on. The last cell in the list will have a `chain` value of
+    *         `None`.
+    */
+  def genChain(length: Int, canonical: CanonicalRecord): Gen[List[ChainCell]] = {
+    val cellGen: Gen[ChainCell] = canonical match {
+      case e: Entity => {
+        val entityGen = Gen.const(e)
+        Gen.oneOf(
+          genEntityUpdateCell(entityGen),
+          genEntityLinkCell(entityGen)
+        )
+      }
+
+      case a: Artefact => {
+        val artefactGen = Gen.const(a)
+        Gen.oneOf(
+          genArtefactUpdateCell(artefactGen),
+          genArtefactCreationCell(artefactGen),
+          genArtefactDerivationCell(artefactGen),
+          genArtefactOwnershipCell(artefactGen),
+          genArtefactReferenceCell(artefactGen)
+        )
+      }
+    }
+
+    for {
+      cells <- Gen.listOfN(length, cellGen)
+    } yield {
+      cells.foldLeft(List[ChainCell]()) { (consedCells, cell) =>
+        val headRef = consedCells.headOption
+          .map(c => MultihashReference.forDataObject(c))
+
+        cell.cons(headRef) :: consedCells
+      }
+    }
+  }
+}

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -72,9 +72,9 @@ object JournalBlockGenerators {
     */
   def genJournalBlock(
     blockSize: Int,
-    datastore: Map[Reference, DataObject],
+    datastore: InMemoryDatastore,
     blockchain: Option[JournalBlock]
-  ): Gen[(JournalBlock, Map[Reference, DataObject])] = {
+  ): Gen[(JournalBlock, InMemoryDatastore)] = {
     // generate ~ twice as many chain cells as canonical entries
     val numCanonicals = (blockSize * 0.3).toInt
     val numChainCells = blockSize - numCanonicals
@@ -103,11 +103,10 @@ object JournalBlockGenerators {
       val block = JournalBlock(blockIndex, prevBlockRef, entries.toArray)
 
       val generatedObjects = block :: (canonicals ++ chainCells)
-      val updatedDatastore = datastore ++ generatedObjects.map { o =>
-        MultihashReference.forDataObject(o) -> o
-      }
 
-      (block, updatedDatastore)
+      val updatedStore = datastore.copy
+      generatedObjects.foreach(updatedStore.put)
+      (block, updatedStore)
     }
   }
 

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -72,8 +72,8 @@ object JournalBlockGenerators {
     */
   def genJournalBlock(
     blockSize: Int,
-    datastore: InMemoryDatastore,
-    blockchain: Option[JournalBlock]
+    datastore: InMemoryDatastore = new InMemoryDatastore,
+    blockchain: Option[JournalBlock] = None
   ): Gen[(JournalBlock, InMemoryDatastore)] = {
     // generate ~ twice as many chain cells as canonical entries
     val numCanonicals = (blockSize * 0.3).toInt
@@ -178,4 +178,13 @@ object JournalBlockGenerators {
 
     canonicalEntries ++ chainEntries
   }
+
+
+  // Arbitrary instances for journal blocks and blockchain, for use with
+  // specs2 scalacheck integration
+  val abJournalBlock: Arbitrary[(JournalBlock, InMemoryDatastore)] =
+    Arbitrary(Gen.sized { size => genJournalBlock(size) })
+
+  val abBlockChain: Arbitrary[(List[JournalBlock], InMemoryDatastore)] =
+    Arbitrary(Gen.sized { size => genBlockChain(size, size * 4) })
 }

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -38,21 +38,17 @@ object JournalBlockGenerators {
     *         `CanonicalRecord`.
     */
   def consChainCells(cells: List[ChainCell]): List[ChainCell] = {
-    import collection.mutable.{Map => MMap, MutableList => MList}
-    val chainHeads: MMap[Reference, ChainCell] = MMap()
-    val consed: MList[ChainCell] = MList()
-
-    cells.foreach { c =>
-      val canonicalRef = c.ref
+    val empty = (Map[Reference, ChainCell](), List[ChainCell]())
+    val (chainHeads, consed) = cells.foldLeft(empty) { (acc, cell) =>
+      val (chainHeads, consed) = acc
+      val canonicalRef = cell.ref
       val head = chainHeads.get(canonicalRef)
         .map(h => MultihashReference.forDataObject(h))
-
-      val consedCell = c.cons(head)
-      chainHeads.put(canonicalRef, consedCell)
-      consed += consedCell
+      val consedCell = cell.cons(head)
+      (chainHeads + (canonicalRef -> consedCell), consed :+ consedCell)
     }
 
-    consed.toList
+    consed
   }
 
 

--- a/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/JournalBlockGenerators.scala
@@ -154,7 +154,7 @@ object JournalBlockGenerators {
       val prevBlockRef = blockchain.map(MultihashReference.forDataObject)
       val block = JournalBlock(blockIndex, prevBlockRef, entries.toArray)
 
-      val generatedObjects = canonicals ++ chainCells
+      val generatedObjects = block :: (canonicals ++ chainCells)
       val updatedDatastore = datastore ++ generatedObjects.map { o =>
         MultihashReference.forDataObject(o) -> o
       }


### PR DESCRIPTION
Just the generators from #66 

Adds scalacheck generators for single journal blocks (with generated `DataObject`s in an `InMemoryDatastore`), and a blockchain of linked blocks.
