### PR TITLE
Copycat.Client: mark state and shutdown as volatile

### DIFF
--- a/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Copycat.scala
@@ -67,8 +67,8 @@ object Copycat {
     import scala.concurrent.ExecutionContext.Implicits.global
     import ClientState._
     
-    private var shutdown = false
-    private var state: ClientState = Disconnected
+    @volatile private var shutdown = false
+    @volatile private var state: ClientState = Disconnected
     private var server: Option[String] = None
     private var reconnectThread: Option[Thread] = None
     private var listeners: Set[JournalListener] = Set()


### PR DESCRIPTION
Adds volatile declarations to the two synchronization variables to discourage the compiler from being too smart about them.
