### PR TITLE
PersistentDatastore: account for race between recovery and copycat journal replay

### DIFF
--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -81,10 +81,8 @@ class PersistentDatastore(config: PersistentDatastore.Config)
     val key = queue.takeFirst
     logger.debug("Writing {}", key.base58)
     try {
-      rocks.getData(key).map { data =>
-        dynamo.putData(key, data)
-        key
-      }
+      rocks.getData(key).foreach {data => dynamo.putData(key, data)}
+      Some(key)
     } catch {
       case e : AmazonClientException =>
         logger.error("AWS Error writing " + key.base58, e)


### PR DESCRIPTION
The race can result in duplicate key queuing. 
If this happens, the second write would have no data in the rocks datastore, which would map to None and trigger back-off without an AWS error.
