### PR TITLE
reproduce the deadlock

### DIFF
--- a/transactor/src/main/scala/io/mediachain/transactor/CurrentBlock.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/CurrentBlock.scala
@@ -1,0 +1,23 @@
+package io.mediachain.transactor
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+import io.mediachain.copycat.Client
+import io.mediachain.protocol.Datastore.JournalBlock
+
+object CurrentBlock {
+  def main(args: Array[String]) {
+    if (args.length != 1) {
+      println("Expected arguments: server-address")
+      System.exit(1)
+    }
+
+    val server = args(0)
+    val client = Client.build()
+    client.connect(server)
+    val block = Await.result(client.currentBlock, Duration.Inf)
+    println(s"Current block is ${block.index}; chain pointer is ${block.chain}")
+    client.close()
+  }
+}

--- a/transactor/src/main/scala/io/mediachain/transactor/Deadlocker.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Deadlocker.scala
@@ -1,0 +1,66 @@
+package io.mediachain.transactor
+
+import java.util.concurrent.Executors
+
+import io.mediachain.copycat._
+import io.mediachain.protocol.Datastore.{Artefact, JournalBlock}
+import io.mediachain.util.cbor.CborAST.CInt
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Random
+
+object Deadlocker {
+  def main(args: Array[String]) {
+    if (args.length != 1) {
+    println("Arguments: server-address")
+    System.exit(1)
+  }
+
+  val serverAddress = args(0)
+  run(serverAddress)
+}
+
+  val executor = Executors.newFixedThreadPool(4)
+  val insertTimeout = 60.seconds
+  val currentBlockTimeout = 60.seconds
+
+  def run(serverAddress: String): Unit = {
+
+    // one thread constantly creates new records
+    executor.execute(new Runnable {
+      override def run(): Unit = {
+        val client = Client.build()
+        println(s"record creation client connecting to $serverAddress")
+        client.connect(serverAddress)
+        println("connected")
+        while (true) {
+          val magicKey = s"foo#${Random.nextInt}"
+          val magicVal = Random.nextInt
+          val a = Artefact(Map(magicKey -> CInt(magicVal)))
+          val result = Await.result(client.insert(a), insertTimeout)
+          if (result.isLeft) {
+            println(s"Error inserting record: $result")
+          }
+        }
+      }
+    })
+
+    // then we make an infinite flatMap chain of requests for the current
+    val client = Client.build()
+    println(s"current block requester client connecting to $serverAddress")
+    client.connect(serverAddress)
+    println("connected")
+
+    println("starting to request blocks")
+    Await.result(requestCurrentBlock(client), Duration.Inf)
+  }
+
+  def requestCurrentBlock(client: Client): Future[JournalBlock] = {
+    client.currentBlock.flatMap { b =>
+      println(s"got current block with index ${b.index}, requesting again")
+      requestCurrentBlock(client)
+    }
+  }
+}


### PR DESCRIPTION
@vyzo this adds a `Deadlocker` client program to the transactor project.  It's very braindead - it just constantly creates new artefacts in a background thread, and awaits an infinite flatMap chain of requests for the current block.

I've been testing it against a local server, but I think my connection to the local dynamo is messed up; I'm getting a bunch of these: 

```
INFO: Unable to execute HTTP request: Unrecognized SSL message, plaintext connection?
javax.net.ssl.SSLException: Unrecognized SSL message, plaintext connection?
    at sun.security.ssl.InputRecord.handleUnknownRecord(InputRecord.java:710)
    at sun.security.ssl.InputRecord.read(InputRecord.java:527)
    at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:973)

...
```

But anyway, it will reliably lock up for me, and interestingly, it always does so after either block #507 or 508 - no idea why, or if it will behave the same on your machine.  When it does fail, the background thread keeps successfully creating blocks, but the request for the current block doesn't retry; it just hangs.

I've been testing with the assembled jar using `java -cp ./transactor/target/scala-2.11/transactor-assembly-0.0.1.jar io.mediachain.transactor.Deadlocker 127.0.0.1:54321`

adding `-Dorg.slf4j.simpleLogger.defaultLogLevel=debug` results in mountains of logs.

I'll try to make this nicer in the morning, but please let me know if you find anything 😄 
