### PR TITLE
Data Model and CBOR serialization updates for rfc-1 schema revisions

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
@@ -293,6 +293,15 @@ object CborSerialization {
 
       CMap.withStringKeys(merged.toList)
     }
+    
+    def toCMapWithMeta(
+      defaults: Map[String, CValue],
+      optionals: Map[String, Option[CValue]],
+      meta: Map[String, CValue])
+    : CMap =
+      toCMapWithDefaults(defaults + ("meta" -> CMap.withStringKeys(meta.toList)),
+                         optionals)
+    
   }
 
   /**
@@ -346,17 +355,19 @@ object CborSerialization {
   object EntityDeserializer extends CborDeserializer[Entity]
   {
     def fromCMap(cMap: CMap): Xor[DeserializationError, Entity] =
-      assertRequiredTypeName(cMap, MediachainTypes.Entity).map { _ =>
-        Entity(cMap.asStringKeyedMap)
-      }
+      for {
+        _ <- assertRequiredTypeName(cMap, MediachainTypes.Entity)
+        meta <- getRequired[CMap](cMap, "meta")
+      } yield Entity(meta.asStringKeyedMap)
   }
 
   object ArtefactDeserializer extends CborDeserializer[Artefact]
   {
     def fromCMap(cMap: CMap): Xor[DeserializationError, Artefact] =
-      assertRequiredTypeName(cMap, MediachainTypes.Artefact).map { _ =>
-        Artefact(cMap.asStringKeyedMap)
-      }
+      for {
+        _ <- assertRequiredTypeName(cMap, MediachainTypes.Artefact)
+        meta <- getRequired[CMap](cMap, "meta")
+      } yield Artefact(meta.asStringKeyedMap)
   }
 
   object ArtefactChainCellDeserializer extends CborDeserializer[ArtefactChainCell]
@@ -365,10 +376,11 @@ object CborSerialization {
       for {
         _ <- assertOneOfRequiredTypeNames(cMap, MediachainTypes.ArtefactChainCellTypes)
         artefact <- getRequiredReference(cMap, "artefact")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactChainCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap
+        meta = meta.asStringKeyedMap
       )
   }
 
@@ -378,10 +390,11 @@ object CborSerialization {
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactUpdateCell)
         artefact <- getRequiredReference(cMap, "artefact")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactUpdateCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap
+        meta = meta.asStringKeyedMap
       )
   }
 
@@ -392,10 +405,11 @@ object CborSerialization {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactLinkCell)
         artefact <- getRequiredReference(cMap, "artefact")
         artefactLink <- getRequiredReference(cMap, "artefactLink")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactLinkCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap,
+        meta = meta.asStringKeyedMap,
         artefactLink = artefactLink
       )
   }
@@ -407,10 +421,11 @@ object CborSerialization {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactCreationCell)
         artefact <- getRequiredReference(cMap, "artefact")
         entity <- getRequiredReference(cMap, "entity")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactCreationCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap,
+        meta = meta.asStringKeyedMap,
         entity = entity
       )
   }
@@ -422,10 +437,11 @@ object CborSerialization {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactDerivationCell)
         artefact <- getRequiredReference(cMap, "artefact")
         artefactOrigin <- getRequiredReference(cMap, "artefactOrigin")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactDerivationCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap,
+        meta = meta.asStringKeyedMap,
         artefactOrigin = artefactOrigin
       )
   }
@@ -437,10 +453,11 @@ object CborSerialization {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactOwnershipCell)
         artefact <- getRequiredReference(cMap, "artefact")
         entity <- getRequiredReference(cMap, "entity")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactOwnershipCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap,
+        meta = meta.asStringKeyedMap,
         entity = entity
       )
   }
@@ -452,10 +469,11 @@ object CborSerialization {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactReferenceCell)
         artefact <- getRequiredReference(cMap, "artefact")
         entity <- getRequiredReference(cMap, "entity")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactReferenceCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap,
+        meta = meta.asStringKeyedMap,
         entity = entity
       )
   }
@@ -466,10 +484,11 @@ object CborSerialization {
       for {
         _ <- assertOneOfRequiredTypeNames(cMap, MediachainTypes.EntityChainCellTypes)
         entity <- getRequiredReference(cMap, "entity")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield EntityChainCell(
         entity = entity,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap
+        meta = meta.asStringKeyedMap
       )
   }
 
@@ -479,10 +498,11 @@ object CborSerialization {
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.EntityUpdateCell)
         entity <- getRequiredReference(cMap, "entity")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield EntityUpdateCell(
         entity = entity,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap
+        meta = meta.asStringKeyedMap
       )
   }
 
@@ -493,10 +513,11 @@ object CborSerialization {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.EntityLinkCell)
         entity <- getRequiredReference(cMap, "entity")
         entityLink <- getRequiredReference(cMap, "entityLink")
+        meta <- getRequired[CMap](cMap, "meta")
       } yield EntityLinkCell(
         entity = entity,
         chain = getOptionalReference(cMap, "chain"),
-        meta = cMap.asStringKeyedMap,
+        meta = meta.asStringKeyedMap,
         entityLink = entityLink
       )
   }

--- a/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
@@ -155,6 +155,7 @@ object CborSerialization {
         case EntityLinkCell.stringValue => Xor.right(EntityLinkCell)
         case ArtefactChainCell.stringValue => Xor.right(ArtefactChainCell)
         case ArtefactUpdateCell.stringValue => Xor.right(ArtefactUpdateCell)
+        case ArtefactLinkCell.stringValue => Xor.right(ArtefactLinkCell)
         case ArtefactCreationCell.stringValue => Xor.right(ArtefactCreationCell)
         case ArtefactDerivationCell.stringValue => Xor.right(ArtefactDerivationCell)
         case ArtefactOwnershipCell.stringValue => Xor.right(ArtefactOwnershipCell)
@@ -194,6 +195,9 @@ object CborSerialization {
     case object ArtefactUpdateCell extends MediachainType {
       val stringValue = "artefactUpdate"
     }
+    case object ArtefactLinkCell extends MediachainType {
+      val stringValue = "artefactLink"
+    }
     case object ArtefactCreationCell extends MediachainType {
       val stringValue = "artefactCreatedBy"
     }
@@ -217,7 +221,7 @@ object CborSerialization {
     }
 
     val ArtefactChainCellTypes: Set[MediachainType] = Set(
-      ArtefactChainCell, ArtefactUpdateCell, ArtefactCreationCell,
+      ArtefactChainCell, ArtefactUpdateCell, ArtefactLinkCell, ArtefactCreationCell,
       ArtefactDerivationCell, ArtefactOwnershipCell, ArtefactReferenceCell
     )
 
@@ -241,6 +245,7 @@ object CborSerialization {
 
       MediachainTypes.ArtefactChainCell -> ArtefactChainCellDeserializer,
       MediachainTypes.ArtefactUpdateCell -> ArtefactChainCellDeserializer,
+      MediachainTypes.ArtefactLinkCell -> ArtefactChainCellDeserializer,
       MediachainTypes.ArtefactCreationCell -> ArtefactChainCellDeserializer,
       MediachainTypes.ArtefactDerivationCell -> ArtefactChainCellDeserializer,
       MediachainTypes.ArtefactOwnershipCell -> ArtefactChainCellDeserializer,
@@ -257,6 +262,7 @@ object CborSerialization {
       MediachainTypes.EntityLinkCell -> EntityLinkCellDeserializer,
 
       MediachainTypes.ArtefactUpdateCell -> ArtefactUpdateCellDeserializer,
+      MediachainTypes.ArtefactLinkCell -> ArtefactLinkCellDeserializer,
       MediachainTypes.ArtefactCreationCell -> ArtefactCreationCellDeserializer,
       MediachainTypes.ArtefactDerivationCell -> ArtefactDerivationCellDeserializer,
       MediachainTypes.ArtefactOwnershipCell -> ArtefactOwnershipCellDeserializer,
@@ -376,6 +382,21 @@ object CborSerialization {
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = cMap.asStringKeyedMap
+      )
+  }
+
+  object ArtefactLinkCellDeserializer extends CborDeserializer[ArtefactLinkCell]
+  {
+    def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactLinkCell] =
+      for {
+        _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactLinkCell)
+        artefact <- getRequiredReference(cMap, "artefact")
+        artefactLink <- getRequiredReference(cMap, "artefactLink")
+      } yield ArtefactLinkCell(
+        artefact = artefact,
+        chain = getOptionalReference(cMap, "chain"),
+        meta = cMap.asStringKeyedMap,
+        artefactLink = artefactLink
       )
   }
 

--- a/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
@@ -375,7 +375,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactChainCell] =
       for {
         _ <- assertOneOfRequiredTypeNames(cMap, MediachainTypes.ArtefactChainCellTypes)
-        artefact <- getRequiredReference(cMap, "artefact")
+        artefact <- getRequiredReference(cMap, "ref")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactChainCell(
         artefact = artefact,
@@ -389,7 +389,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactUpdateCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactUpdateCell)
-        artefact <- getRequiredReference(cMap, "artefact")
+        artefact <- getRequiredReference(cMap, "ref")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactUpdateCell(
         artefact = artefact,
@@ -403,7 +403,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactLinkCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactLinkCell)
-        artefact <- getRequiredReference(cMap, "artefact")
+        artefact <- getRequiredReference(cMap, "ref")
         artefactLink <- getRequiredReference(cMap, "artefactLink")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactLinkCell(
@@ -419,7 +419,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactCreationCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactCreationCell)
-        artefact <- getRequiredReference(cMap, "artefact")
+        artefact <- getRequiredReference(cMap, "ref")
         entity <- getRequiredReference(cMap, "entity")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactCreationCell(
@@ -435,7 +435,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactDerivationCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactDerivationCell)
-        artefact <- getRequiredReference(cMap, "artefact")
+        artefact <- getRequiredReference(cMap, "ref")
         artefactOrigin <- getRequiredReference(cMap, "artefactOrigin")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactDerivationCell(
@@ -451,7 +451,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactOwnershipCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactOwnershipCell)
-        artefact <- getRequiredReference(cMap, "artefact")
+        artefact <- getRequiredReference(cMap, "ref")
         entity <- getRequiredReference(cMap, "entity")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactOwnershipCell(
@@ -467,7 +467,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, ArtefactReferenceCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactReferenceCell)
-        artefact <- getRequiredReference(cMap, "artefact")
+        artefact <- getRequiredReference(cMap, "ref")
         entity <- getRequiredReference(cMap, "entity")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactReferenceCell(
@@ -483,7 +483,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, EntityChainCell] =
       for {
         _ <- assertOneOfRequiredTypeNames(cMap, MediachainTypes.EntityChainCellTypes)
-        entity <- getRequiredReference(cMap, "entity")
+        entity <- getRequiredReference(cMap, "ref")
         meta <- getRequired[CMap](cMap, "meta")
       } yield EntityChainCell(
         entity = entity,
@@ -497,7 +497,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, EntityUpdateCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.EntityUpdateCell)
-        entity <- getRequiredReference(cMap, "entity")
+        entity <- getRequiredReference(cMap, "ref")
         meta <- getRequired[CMap](cMap, "meta")
       } yield EntityUpdateCell(
         entity = entity,
@@ -511,7 +511,7 @@ object CborSerialization {
     def fromCMap(cMap: CMap): Xor[DeserializationError, EntityLinkCell] =
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.EntityLinkCell)
-        entity <- getRequiredReference(cMap, "entity")
+        entity <- getRequiredReference(cMap, "ref")
         entityLink <- getRequiredReference(cMap, "entityLink")
         meta <- getRequired[CMap](cMap, "meta")
       } yield EntityLinkCell(

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -33,7 +33,7 @@ object Datastore {
 
   // Content-addressable reference using IPFS MultiHash
   case class MultihashReference(multihash: MultiHash) extends Reference {
-    val mediachainType: Option[MediachainType] = None
+    override val mediachainType: Option[MediachainType] = None
 
     override def toCbor: CValue =
       CMap.withStringKeys("@link" -> CBytes(multihash.bytes))
@@ -54,7 +54,8 @@ object Datastore {
   case class Entity(
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val mediachainType: Option[MediachainType] = Some(MediachainTypes.Entity)
+    override val mediachainType: Option[MediachainType] = 
+      Some(MediachainTypes.Entity)
 
     override def toCbor =
       super.toCMapWithMeta(Map(), Map(), meta)
@@ -65,7 +66,8 @@ object Datastore {
   case class Artefact(
     meta: Map[String, CValue]
   ) extends CanonicalRecord {
-    val mediachainType: Option[MediachainType] = Some(MediachainTypes.Artefact)
+    override val mediachainType: Option[MediachainType] = 
+      Some(MediachainTypes.Artefact)
 
     override def toCbor =
       super.toCMapWithMeta(Map(), Map(), meta)
@@ -97,10 +99,8 @@ object Datastore {
     override def cons(xchain: Option[Reference]): ChainCell =
       EntityChainCell(entity, xchain, meta)
 
-    val mediachainType: Option[MediachainType] =
-      meta.get("type")
-        .flatMap(t => MediachainTypes.fromCValue(t).toOption)
-        .orElse(Some(MediachainTypes.EntityChainCell))
+    override val mediachainType: Option[MediachainType] = 
+      Some(MediachainTypes.EntityChainCell)
   }
 
   object EntityChainCell {
@@ -121,10 +121,8 @@ object Datastore {
     override def cons(xchain: Option[Reference]): ChainCell =
       ArtefactChainCell(artefact, xchain, meta)
     
-    val mediachainType: Option[MediachainType] =
-      meta.get("type")
-        .flatMap(t => MediachainTypes.fromCValue(t).toOption)
-        .orElse(Some(MediachainTypes.ArtefactChainCell))
+    override val mediachainType: Option[MediachainType] =
+      Some(MediachainTypes.ArtefactChainCell)
   }
 
   object ArtefactChainCell {
@@ -300,7 +298,8 @@ object Datastore {
     index: BigInt,
     ref: Reference
   ) extends JournalEntry {
-    val mediachainType: Option[MediachainType] = Some(MediachainTypes.CanonicalEntry)
+    override val mediachainType: Option[MediachainType] = 
+      Some(MediachainTypes.CanonicalEntry)
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -318,7 +317,8 @@ object Datastore {
     chain: Reference,
     chainPrevious: Option[Reference]
   ) extends JournalEntry {
-    val mediachainType: Option[MediachainType] = Some(MediachainTypes.ChainEntry)
+    override val mediachainType: Option[MediachainType] = 
+      Some(MediachainTypes.ChainEntry)
 
     override def toCbor: CValue = {
       val defaults = Map(
@@ -339,7 +339,8 @@ object Datastore {
     chain: Option[Reference],
     entries: Array[JournalEntry]
   ) extends DataObject {
-    val mediachainType: Option[MediachainType] = Some(MediachainTypes.JournalBlock)
+    override val mediachainType: Option[MediachainType] = 
+      Some(MediachainTypes.JournalBlock)
 
     override def toCbor = {
       val cborEntries = CArray(entries.map(_.toCbor).toList)

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -57,7 +57,7 @@ object Datastore {
     val mediachainType: Option[MediachainType] = Some(MediachainTypes.Entity)
 
     override def toCbor =
-      super.toCMapWithDefaults(meta, Map())
+      super.toCMapWithMeta(Map(), Map(), meta)
 
     def reference: ChainReference = EntityChainReference.empty
   }
@@ -68,7 +68,7 @@ object Datastore {
     val mediachainType: Option[MediachainType] = Some(MediachainTypes.Artefact)
 
     override def toCbor =
-      super.toCMapWithDefaults(meta, Map())
+      super.toCMapWithMeta(Map(), Map(), meta)
 
     def reference: ChainReference = ArtefactChainReference.empty
   }
@@ -97,9 +97,9 @@ object Datastore {
         .orElse(Some(MediachainTypes.EntityChainCell))
 
     override def toCbor = {
-      val defaults = meta + ("entity" -> entity.toCbor)
+      val defaults = Map("entity" -> entity.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
   }
 
@@ -127,9 +127,9 @@ object Datastore {
         .orElse(Some(MediachainTypes.ArtefactChainCell))
 
     override def toCbor = {
-      val defaults = meta + ("artefact" -> artefact.toCbor)
+      val defaults = Map("artefact" -> artefact.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
   }
 
@@ -169,10 +169,10 @@ object Datastore {
       Some(MediachainTypes.EntityLinkCell)
 
     override def toCbor = {
-      val defaults = meta + ("entity" -> entity.toCbor) +
-        ("entityLink" -> entityLink.toCbor)
+      val defaults = Map("entity" -> entity.toCbor,
+                         "entityLink" -> entityLink.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
   }
 
@@ -203,10 +203,10 @@ object Datastore {
       Some(MediachainTypes.ArtefactLinkCell)
     
     override def toCbor = {
-      val defaults = meta + ("artefact" -> artefact.toCbor) +
-        ("artefactLink" -> artefactLink.toCbor)
+      val defaults = Map("artefact" -> artefact.toCbor,
+                         "artefactLink" -> artefactLink.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
 
   }
@@ -225,10 +225,10 @@ object Datastore {
       Some(MediachainTypes.ArtefactCreationCell)
 
     override def toCbor = {
-      val defaults = meta + ("artefact" -> artefact.toCbor) +
-        ("entity" -> entity.toCbor)
+      val defaults = Map("artefact" -> artefact.toCbor,
+                         "entity" -> entity.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
   }
 
@@ -246,11 +246,11 @@ object Datastore {
       Some(MediachainTypes.ArtefactDerivationCell)
 
     override def toCbor = {
-      val defaults = meta + ("artefact" -> artefact.toCbor) +
-        ("artefactOrigin" -> artefactOrigin.toCbor)
+      val defaults = Map("artefact" -> artefact.toCbor,
+                         "artefactOrigin" -> artefactOrigin.toCbor)
 
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
   }
 
@@ -268,10 +268,10 @@ object Datastore {
       Some(MediachainTypes.ArtefactOwnershipCell)
 
     override def toCbor = {
-      val defaults = meta + ("artefact" -> artefact.toCbor) +
-        ("entity" -> entity.toCbor)
+      val defaults = Map("artefact" -> artefact.toCbor,
+                         "entity" -> entity.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
   }
 
@@ -289,10 +289,10 @@ object Datastore {
       Some(MediachainTypes.ArtefactReferenceCell)
 
     override def toCbor = {
-      val defaults = meta + ("artefact" -> artefact.toCbor) +
-        ("entity" -> entity.toCbor)
+      val defaults = Map("artefact" -> artefact.toCbor,
+                         "entity" -> entity.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithDefaults(defaults, optionals)
+      super.toCMapWithMeta(defaults, optionals, meta)
     }
   }
 

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -190,6 +190,27 @@ object Datastore {
       Some(MediachainTypes.ArtefactUpdateCell)
   }
 
+  case class ArtefactLinkCell(
+    override val artefact: Reference,
+    override val chain: Option[Reference],
+    override val meta: Map[String, CValue],
+    artefactLink: Reference
+  ) extends ArtefactChainCell(artefact, chain, meta) {
+    override def cons(xchain: Option[Reference]): ChainCell =
+      ArtefactLinkCell(artefact, xchain, meta, artefactLink)
+
+    override val mediachainType: Option[MediachainType] =
+      Some(MediachainTypes.ArtefactLinkCell)
+    
+    override def toCbor = {
+      val defaults = meta + ("artefact" -> artefact.toCbor) +
+        ("artefactLink" -> artefactLink.toCbor)
+      val optionals = Map("chain" -> chain.map(_.toCbor))
+      super.toCMapWithDefaults(defaults, optionals)
+    }
+
+  }
+
   case class ArtefactCreationCell(
     override val artefact: Reference,
     override val chain: Option[Reference],

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -79,6 +79,12 @@ object Datastore {
     def ref: Reference
     def chain: Option[Reference]
     def cons(chain: Option[Reference]): ChainCell
+    
+    override def toCbor = {
+      val defaults = Map("ref" -> ref.toCbor)
+      val optionals = Map("chain" -> chain.map(_.toCbor))
+      super.toCMapWithMeta(defaults, optionals, meta)
+    }
   }
 
   class EntityChainCell(
@@ -95,12 +101,6 @@ object Datastore {
       meta.get("type")
         .flatMap(t => MediachainTypes.fromCValue(t).toOption)
         .orElse(Some(MediachainTypes.EntityChainCell))
-
-    override def toCbor = {
-      val defaults = Map("entity" -> entity.toCbor)
-      val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithMeta(defaults, optionals, meta)
-    }
   }
 
   object EntityChainCell {
@@ -125,12 +125,6 @@ object Datastore {
       meta.get("type")
         .flatMap(t => MediachainTypes.fromCValue(t).toOption)
         .orElse(Some(MediachainTypes.ArtefactChainCell))
-
-    override def toCbor = {
-      val defaults = Map("artefact" -> artefact.toCbor)
-      val optionals = Map("chain" -> chain.map(_.toCbor))
-      super.toCMapWithMeta(defaults, optionals, meta)
-    }
   }
 
   object ArtefactChainCell {
@@ -169,7 +163,7 @@ object Datastore {
       Some(MediachainTypes.EntityLinkCell)
 
     override def toCbor = {
-      val defaults = Map("entity" -> entity.toCbor,
+      val defaults = Map("ref" -> entity.toCbor,
                          "entityLink" -> entityLink.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithMeta(defaults, optionals, meta)
@@ -203,7 +197,7 @@ object Datastore {
       Some(MediachainTypes.ArtefactLinkCell)
     
     override def toCbor = {
-      val defaults = Map("artefact" -> artefact.toCbor,
+      val defaults = Map("ref" -> artefact.toCbor,
                          "artefactLink" -> artefactLink.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithMeta(defaults, optionals, meta)
@@ -225,7 +219,7 @@ object Datastore {
       Some(MediachainTypes.ArtefactCreationCell)
 
     override def toCbor = {
-      val defaults = Map("artefact" -> artefact.toCbor,
+      val defaults = Map("ref" -> artefact.toCbor,
                          "entity" -> entity.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithMeta(defaults, optionals, meta)
@@ -246,7 +240,7 @@ object Datastore {
       Some(MediachainTypes.ArtefactDerivationCell)
 
     override def toCbor = {
-      val defaults = Map("artefact" -> artefact.toCbor,
+      val defaults = Map("ref" -> artefact.toCbor,
                          "artefactOrigin" -> artefactOrigin.toCbor)
 
       val optionals = Map("chain" -> chain.map(_.toCbor))
@@ -268,7 +262,7 @@ object Datastore {
       Some(MediachainTypes.ArtefactOwnershipCell)
 
     override def toCbor = {
-      val defaults = Map("artefact" -> artefact.toCbor,
+      val defaults = Map("ref" -> artefact.toCbor,
                          "entity" -> entity.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithMeta(defaults, optionals, meta)
@@ -289,7 +283,7 @@ object Datastore {
       Some(MediachainTypes.ArtefactReferenceCell)
 
     override def toCbor = {
-      val defaults = Map("artefact" -> artefact.toCbor,
+      val defaults = Map("ref" -> artefact.toCbor,
                          "entity" -> entity.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithMeta(defaults, optionals, meta)

--- a/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
@@ -25,6 +25,7 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
 
           - artefact chain cell $roundTripArtefactChainCell
           - artefact update cell $roundTripArtefactUpdateCell
+          - artefact link cell $roundTripArtefactLinkCell
           - artefact creation cell $roundTripArtefactCreationCell
           - artefact derivation cell $roundTripArtefactDerivationCell
           - artefact ownership cell $roundTripArtefactOwnershipCell
@@ -134,6 +135,16 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
     }
   }
 
+  def roundTripArtefactLinkCell = prop { c: ArtefactLinkCell =>
+    val cbor = c.toCbor
+    cbor must matchTypeName(MediachainTypes.ArtefactLinkCell)
+
+    fromCbor(cbor) must beRightXor { obj: ArtefactLinkCell =>
+      obj must matchArtefactChainCell(c)
+      obj.artefactLink must_== c.artefactLink
+    }
+  }
+
   def roundTripArtefactCreationCell = prop { c: ArtefactCreationCell =>
     val cbor = c.toCbor
     cbor must matchTypeName(MediachainTypes.ArtefactCreationCell)
@@ -220,6 +231,7 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
     }.setGen(Gen.oneOf(
         genArtefactReferenceCell,
         genArtefactUpdateCell,
+        genArtefactLinkCell,
         genArtefactOwnershipCell,
         genArtefactDerivationCell,
         genArtefactCreationCell

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -99,6 +99,17 @@ object DataObjectGenerators {
   val genArtefactUpdateCell: Gen[ArtefactUpdateCell] =
     genArtefactUpdateCell(genArtefact, genOptionalReference)
 
+  def genArtefactLinkCell(
+    artefactGen: Gen[Artefact],
+    chainGen: Gen[Option[Reference]],
+    artefactLinkGen: Gen[Reference]
+  ) = for {
+    base <- genArtefactChainCell(artefactGen, chainGen)
+    artefactLink <- artefactLinkGen
+  } yield ArtefactLinkCell(base.artefact, base.chain, base.meta, artefactLink)
+  val genArtefactLinkCell: Gen[ArtefactLinkCell] =
+    genArtefactLinkCell(genArtefact, genOptionalReference, genReference)
+
   def genArtefactCreationCell(
     artefactGen: Gen[Artefact],
     chainGen: Gen[Option[Reference]],
@@ -168,6 +179,7 @@ object DataObjectGenerators {
   implicit def abEntityUpdateCell: Arbitrary[EntityUpdateCell] = Arbitrary(genEntityUpdateCell)
   implicit def abEntityLinkCell: Arbitrary[EntityLinkCell] = Arbitrary(genEntityLinkCell)
   implicit def abArtefactUpdateCell: Arbitrary[ArtefactUpdateCell] = Arbitrary(genArtefactUpdateCell)
+  implicit def abArtefactLinkCell: Arbitrary[ArtefactLinkCell] = Arbitrary(genArtefactLinkCell)
   implicit def abArtefactCreationCell: Arbitrary[ArtefactCreationCell] = Arbitrary(genArtefactCreationCell)
   implicit def abArtefactDerivationCell: Arbitrary[ArtefactDerivationCell] = Arbitrary(genArtefactDerivationCell)
   implicit def abArtefactOwnershipCell: Arbitrary[ArtefactOwnershipCell] = Arbitrary(genArtefactOwnershipCell)


### PR DESCRIPTION
- Adds ArtefactLinkCell
- Aggregate record meta data go to a "meta" field in CBOR
- ChainCells have a common "ref" for canonical references
