### PR TITLE
CBOR serialization for JournalBlocks in Copycat

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -29,7 +29,7 @@ object Datastore {
 
 
   // References to records in the underlying datastore
-  abstract class Reference extends Serializable with CborSerializable
+  sealed abstract class Reference extends Serializable with CborSerializable
 
   // Content-addressable reference using IPFS MultiHash
   case class MultihashReference(multihash: MultiHash) extends Reference {
@@ -44,6 +44,13 @@ object Datastore {
       MultihashReference(
         MultiHash.hashWithSHA256(dataObject.toCborBytes)
       )
+  }
+  
+  // DummyReferences are used for testing but still need to be CBOR serializable
+  case class DummyReference(index: Int) extends Reference {
+    override val mediachainType: Option[MediachainType] = None
+    override def toCbor: CValue =
+      CMap.withStringKeys("@dummy" -> CInt(index))
   }
 
   // Canonical records: Entities and Artefacts

--- a/protocol/src/main/scala/io/mediachain/util/cbor/CborAST.scala
+++ b/protocol/src/main/scala/io/mediachain/util/cbor/CborAST.scala
@@ -39,6 +39,12 @@ object CborAST {
     def getAs[T <: CValue](key: String): Option[T] =
       getAs(CString(key))
     
+    def contains(key: String) =
+      fields.exists {
+        case (CString(fkey), _) =>
+          key == fkey
+        case _ => false
+      }
   }
   type CField = (CValue, CValue)
 

--- a/transactor/src/main/scala/io/mediachain/copycat/Dummies.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Dummies.scala
@@ -6,28 +6,12 @@ object Dummies {
   import io.mediachain.protocol.Datastore._
   import io.mediachain.util.cbor.CborAST._
 
-  class DummyReference(val num: Int) extends Reference {
-    override def equals(that: Any) = {
-      that.isInstanceOf[DummyReference] &&
-        this.num == that.asInstanceOf[DummyReference].num
-    }
-    override def hashCode = num
-    override def toString = "dummy@" + num
-
-    // CBOR serialization is not used for dummy references,
-    // but having the base Reference type implement CborSerializable
-    // greatly simplifies the serialization logic for objects that contain
-    // references.
-    val mediachainType = None
-    override def toCbor = CMap.withStringKeys("@dummy-link" -> CInt(num))
-  }
-
   class DummyStore extends Datastore {
     var seqno = 0
     val store: MMap[Reference, DataObject] = new MHashMap
 
     override def put(obj: DataObject): Reference = {
-      val ref = new DummyReference(seqno)
+      val ref = DummyReference(seqno)
       seqno += 1
       store += (ref -> obj)
       ref

--- a/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
@@ -1,6 +1,10 @@
 package io.mediachain.copycat
 
-import io.atomix.catalyst.serializer.Serializer
+import io.atomix.catalyst.serializer.{Serializer, TypeSerializer, SerializationException}
+import io.atomix.catalyst.buffer.{BufferInput, BufferOutput}
+import cats.data.Xor
+import io.mediachain.protocol.Datastore.JournalBlock
+import io.mediachain.protocol.CborSerialization
 import io.mediachain.copycat.StateMachine._
 
 object Serializers {
@@ -11,7 +15,33 @@ object Serializers {
                      classOf[JournalCommitEvent],
                      classOf[JournalBlockEvent],
                      classOf[JournalState])
+  
   def register(serializer: Serializer) {
     klasses.foreach(serializer.register(_))
+    serializer.register(classOf[JournalBlock], classOf[JournalBlockSerializer])
   }
+  
+  class JournalBlockSerializer extends TypeSerializer[JournalBlock] {
+    def read(klass: Class[JournalBlock], buf: BufferInput[_ <: BufferInput[_]], ser: Serializer)
+    : JournalBlock = {
+      val len = buf.readInt()
+      val bytes = new Array[Byte](len)
+      buf.read(bytes)
+      CborSerialization.dataObjectFromCborBytes(bytes) match {
+        case Xor.Right(block: JournalBlock) => 
+          block
+        case Xor.Right(obj) =>
+          throw new SerializationException("Failed to deserialize JournalBlock: unexpected object " + obj)
+        case Xor.Left(err) =>
+          throw new SerializationException("Failed to deserialize JournalBlock: " + err.message)
+      }
+    }
+    
+    def write(block: JournalBlock, buf: BufferOutput[_ <: BufferOutput[_]], ser: Serializer) {
+      val bytes = block.toCborBytes
+      buf.writeInt(bytes.length)
+      buf.write(bytes)
+    }
+  }
+
 }


### PR DESCRIPTION
Blocks serialized with CBOR are half-size compared to their POJO form, so this adds a custom Serializer for them in copycat.
In order to do this and still have tests with dummy references, the DummyReference becomes a first-class citizen of protocol-land.
