### PR TITLE
RFC1 schema tweaks and protocol updates

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
@@ -436,13 +436,13 @@ object CborSerialization {
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactDerivationCell)
         artefact <- getRequiredReference(cMap, "ref")
-        artefactOrigin <- getRequiredReference(cMap, "artefactOrigin")
+        artefactLink <- getRequiredReference(cMap, "artefactLink")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactDerivationCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
-        artefactOrigin = artefactOrigin
+        artefactLink = artefactLink
       )
   }
 
@@ -468,13 +468,12 @@ object CborSerialization {
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.ArtefactReferenceCell)
         artefact <- getRequiredReference(cMap, "ref")
-        entity <- getRequiredReference(cMap, "entity")
         meta <- getRequired[CMap](cMap, "meta")
       } yield ArtefactReferenceCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
-        entity = entity
+        entity = getOptionalReference(cMap, "entity")
       )
   }
 

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -235,19 +235,18 @@ object Datastore {
     override val artefact: Reference,
     override val chain: Option[Reference],
     override val meta: Map[String, CValue],
-    artefactOrigin: Reference
+    artefactLink: Reference
   ) extends ArtefactChainCell(artefact, chain, meta)
   {
     override def cons(xchain: Option[Reference]): ChainCell =
-      ArtefactDerivationCell(artefact, xchain, meta, artefactOrigin)
+      ArtefactDerivationCell(artefact, xchain, meta, artefactLink)
 
     override val mediachainType: Option[MediachainType] =
       Some(MediachainTypes.ArtefactDerivationCell)
 
     override def toCbor = {
       val defaults = Map("ref" -> artefact.toCbor,
-                         "artefactOrigin" -> artefactOrigin.toCbor)
-
+                         "artefactLink" -> artefactLink.toCbor)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithMeta(defaults, optionals, meta)
     }
@@ -278,7 +277,7 @@ object Datastore {
     override val artefact: Reference,
     override val chain: Option[Reference],
     override val meta: Map[String, CValue],
-    entity: Reference
+    entity: Option[Reference]
   ) extends ArtefactChainCell(artefact, chain, meta)
   {
     override def cons(xchain: Option[Reference]): ChainCell =
@@ -288,9 +287,9 @@ object Datastore {
       Some(MediachainTypes.ArtefactReferenceCell)
 
     override def toCbor = {
-      val defaults = Map("ref" -> artefact.toCbor,
-                         "entity" -> entity.toCbor)
-      val optionals = Map("chain" -> chain.map(_.toCbor))
+      val defaults = Map("ref" -> artefact.toCbor)
+      val optionals = Map("chain" -> chain.map(_.toCbor),
+                          "entity" -> entity.map(_.toCbor))
       super.toCMapWithMeta(defaults, optionals, meta)
     }
   }

--- a/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
@@ -161,7 +161,7 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
 
     fromCbor(cbor) must beRightXor { obj: ArtefactDerivationCell =>
       obj must matchArtefactChainCell(c)
-      obj.artefactOrigin must_== c.artefactOrigin
+      obj.artefactLink must_== c.artefactLink
     }
   }
 

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -146,13 +146,13 @@ object DataObjectGenerators {
   def genArtefactReferenceCell(
     artefactGen: Gen[Artefact],
     chainGen: Gen[Option[Reference]],
-    entityGen: Gen[Reference]
+    entityGen: Gen[Option[Reference]]
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- entityGen
   } yield ArtefactReferenceCell(base.artefact, base.chain, base.meta, entity)
   val genArtefactReferenceCell: Gen[ArtefactReferenceCell] =
-    genArtefactReferenceCell(genArtefact, genOptionalReference, genReference)
+    genArtefactReferenceCell(genArtefact, genOptionalReference, genOptionalReference)
 
   val genCanonicalEntry =
     (arbitrary[BigInt] |@| genReference).map(CanonicalEntry)

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -243,7 +243,7 @@ ArtefactDerivationCell = {
  "type" : "artefactDerivedBy"
  "chain" : <Reference>
  "ref" : <Reference>
- "artefactOrigin" : <Reference>
+ "artefactLink" : <Reference> ; original artefact
  "signatures" : <Signatures>
  "meta" : {
   <Key> : <Value> ... ; derivation metadata
@@ -265,9 +265,9 @@ ArtefactReferenceCell = {
  "type" : "artefactReferencedBy"
  "chain" : <Reference>
  "ref" : <Reference>
+ ["entity" : <Reference>]
  "signatures" : <Signatures>
  "meta" : {
-  ["entity" : <Reference>]
   ["url" : <URL>]
   <Key> : <Value> ... ; reference metadata
   }

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -453,7 +453,7 @@ QmIII... = ArtefactDerivationCell {
  "type" : "artefactDerivedBy"
  "chain" : {"@link" : "QmHHH..."}
  "ref" : {"@link" : "QmGGG..."}
- "artefactOrigin" : {"@link" : "QmBBB..."}
+ "artefactLink" : {"@link" : "QmBBB..."}
  "meta" : {
   "comment" : "I derived it from +hellengreen's GIF.!"
   }


### PR DESCRIPTION
Tweaks in rfc1 schema and updates in the protocol data model to reflect them
- ArtefactDerivationCell has an artefactLink instead of artefactOrigin
- ArtefactReferenceCell gets the optional entity reference in the structure
