### PR TITLE
Serialize copycat commands as CBOR bytes

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
@@ -81,6 +81,21 @@ object CborSerialization {
     fromCborBytes[JournalEntry](bytes)(deserializers)
 
 
+  /**
+    * Try to deserialize a `Reference` from a cbor-encoded byte array
+    * @param bytes the byte array to deserialize from
+    * @return the decoded `Reference`, or a `DeserializationError` on failure
+    */
+  def referenceFromCborBytes(bytes: Array[Byte])
+  : Xor[DeserializationError, Reference] = {
+    val refMapXor = CborCodec.decode(bytes) match {
+      case (_: CTag) :: (refMap: CMap) :: _ => Xor.right(refMap)
+      case (refMap: CMap) :: _ => Xor.right(refMap)
+      case _ => Xor.left(CborDecodingFailed())
+    }
+
+    refMapXor.flatMap(ReferenceDeserializer.fromCMap)
+  }
 
   /**
     * Try to deserialize some `CborSerializable` object from a byte array.

--- a/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
@@ -6,6 +6,7 @@ import cats.data.Xor
 import io.mediachain.protocol.Datastore._
 import io.mediachain.protocol.CborSerialization
 import io.mediachain.copycat.StateMachine._
+import io.mediachain.util.cbor.CborCodec
 
 object Serializers {
   val klasses = List(classOf[JournalLookup],
@@ -79,7 +80,7 @@ object Serializers {
       buf.read(cellBytes)
 
       val updateXor = for {
-        ref <- CborSerialization.fromCborBytes[Reference](refBytes)
+        ref <- CborSerialization.referenceFromCborBytes(refBytes)
         cell <- CborSerialization.fromCborBytes[ChainCell](cellBytes)
       } yield JournalUpdate(ref, cell)
 

--- a/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
@@ -38,11 +38,9 @@ object Serializers {
     def read(klass: Class[JournalBlock], buf: BufferInput[_ <: BufferInput[_]], ser: Serializer)
     : JournalBlock = {
       val bytes = readBytes(buf)
-      CborSerialization.dataObjectFromCborBytes(bytes) match {
-        case Xor.Right(block: JournalBlock) => 
+      CborSerialization.fromCborBytes[JournalBlock](bytes) match {
+        case Xor.Right(block) => 
           block
-        case Xor.Right(obj) =>
-          throw new SerializationException("Failed to deserialize JournalBlock: unexpected object " + obj)
         case Xor.Left(err) =>
           throw new SerializationException("Failed to deserialize JournalBlock: " + err.message)
       }
@@ -57,11 +55,9 @@ object Serializers {
     def read(klass: Class[JournalInsert], buf: BufferInput[_ <: BufferInput[_]], ser: Serializer)
     : JournalInsert = {
       val bytes = readBytes(buf)
-      CborSerialization.dataObjectFromCborBytes(bytes) match {
-        case Xor.Right(record: CanonicalRecord) =>
+      CborSerialization.fromCborBytes[CanonicalRecord](bytes) match {
+        case Xor.Right(record) => 
           JournalInsert(record)
-        case Xor.Right(obj) =>
-          throw new SerializationException("Failed to deserialize JournalInsert: unexpected object " + obj)
         case Xor.Left(err) =>
           throw new SerializationException("Failed to deserialize JournalInsert: " + err.message)
       }

--- a/transactor/src/test/scala/io/mediachain/copycat/CopycatSerializerSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/CopycatSerializerSpec.scala
@@ -1,0 +1,58 @@
+package io.mediachain.copycat
+
+import io.atomix.catalyst.buffer.DirectBuffer
+import io.atomix.catalyst.serializer.{Serializer, TypeSerializer}
+import io.mediachain.BaseSpec
+import io.mediachain.multihash.MultiHash
+
+import scala.util.Random
+
+object CopycatSerializerSpec extends BaseSpec {
+  import Serializers._
+  import io.mediachain.copycat.StateMachine._
+  import io.mediachain.protocol.Datastore._
+  import io.mediachain.util.cbor.CborAST._
+
+
+  def is =
+    s2"""
+       round-trip serializes:
+         - JournalInsert $journalInsertRoundTrip
+         - JournalUpdate $journalUpdateRoundTrip
+         - JournalLookup $journalLookupRoundTrip
+      """
+
+  private def roundTrip[T](value: T, typeSerializer: TypeSerializer[T]) = {
+    val buffer = DirectBuffer.allocate()
+    val serializer = new Serializer()
+    serializer.register(value.getClass, typeSerializer.getClass)
+    typeSerializer.write(value, buffer, serializer)
+    buffer.position(0)
+    val deserialized = typeSerializer.read(value.getClass.asInstanceOf[Class[T]], buffer, serializer)
+    deserialized must_== value
+  }
+
+  private def randomRef: Reference =
+    MultihashReference(MultiHash.hashWithSHA256(Random.nextString(100).getBytes))
+
+  def journalInsertRoundTrip = {
+    val meta = Map("foo" -> CMap(CString("bar") -> CString("baz")))
+    val insert = JournalInsert(Entity(meta))
+
+    roundTrip(insert, new JournalInsertSerializer)
+  }
+
+  def journalUpdateRoundTrip = {
+    val meta = Map("foo" -> CMap(CString("bar") -> CString("baz")))
+    val ref = randomRef
+    val update = JournalUpdate(ref, EntityUpdateCell(ref, None, meta))
+
+    roundTrip(update, new JournalUpdateSerializer)
+  }
+
+  def journalLookupRoundTrip = {
+    val ref = randomRef
+    val lookup = JournalLookup(ref)
+    roundTrip(lookup, new JournalLookupSerializer)
+  }
+}


### PR DESCRIPTION
This adds custom copycat `TypeSerializer`s for the `JournalInsert`, `JournalUpdate` and `JournalLookup` commands, to fix the serialization bug when sending nested cbor maps in the `meta` field of an object.
