### PR TITLE
copycat: reduce blocksize, add cluster connect to client

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
@@ -36,7 +36,8 @@ object Transactor {
   }
 
   trait JournalClient extends Journal {
-    def connect(address: String): Unit
+    def connect(cluster: List[String]): Unit
+    def connect(address: String) {connect(List(address))}
     def close(): Unit
     def listen(listener: JournalListener): Unit
   }

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -16,7 +16,7 @@ object StateMachine {
   import io.mediachain.protocol.Datastore._
   import io.mediachain.protocol.Transactor._
 
-  val JournalBlockSize: Int = 4096 // blocksize for Journal Blockchain
+  val JournalBlockSize: Int = 512 // blocksize for Journal Blockchain
   
   case class JournalInsert(
     record: CanonicalRecord


### PR DESCRIPTION
With blocksize reduced to 512 entries/block there is no need for chunking, which makes expensive proviosioning for the chunk table redundant. 
Note: the dynamo chunking code sticks around for now as it is required for a generic datastore solution.
