### PR TITLE
transactor: signal JournalDuplicateError on duplicate inserts

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
@@ -52,4 +52,8 @@ object Transactor {
   case class JournalCommitError(what: String) extends JournalError {
     override def toString = "Journal Commit Error: " + what
   }
+  
+  case class JournalDuplicateError(ref: Reference) extends JournalError {
+    override def toString = "Duplicate Journal Insert: " + ref
+  }
 }

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -67,10 +67,11 @@ object StateMachine {
       val rec = cmd.record
       val ref = datastore.put(rec)
       state.index.get(ref) match {
-        case Some(_) => commitError("duplicate insert")
+        case Some(_) => 
+          Xor.left(JournalDuplicateError(ref))
+          
         case None => {
           state.index += (ref -> rec.reference)
-
           val entry = CanonicalEntry(nextSeqno(), ref)
           publishCommit(entry)
           blockExtend(entry)


### PR DESCRIPTION
Facilitate deduplication with a specific error that includes the reference to the duplicate object.
