### PR TITLE
Tweaks in transactor server

### DIFF
--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -70,7 +70,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
         case None => 
           val xbackoff = Math.min(maxBackoffRetry, Math.max(1, 2 * backoff))
           val sleep = random.nextInt(1000 * xbackoff)
-          logger.info("Backing off for " + sleep + "ms")
+          logger.info("Backing off for " + sleep + "ms; queue backlog: " + queue.size)
           Thread.sleep(sleep)
           loop(xbackoff)
       }

--- a/transactor/src/main/scala/io/mediachain/transactor/JournalServer.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/JournalServer.scala
@@ -20,10 +20,10 @@ object JournalServer {
   }
   
   def parseArgs(args: Array[String]) = {
-    args match {
-      case Array("-i", config, cluster@_*) =>
+    args.toList match {
+      case "-i" :: config :: cluster =>
         (true, config, cluster.toList)
-      case Array(config, cluster@_*) =>
+      case config :: cluster =>
         (false, config, cluster.toList)
       case _ =>
         throw new RuntimeException("Expected arguments: [-i] config [cluster-address ...]")

--- a/transactor/src/main/scala/io/mediachain/transactor/JournalServer.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/JournalServer.scala
@@ -4,26 +4,33 @@ import java.util.Properties
 import java.io.FileInputStream
 import com.amazonaws.auth.BasicAWSCredentials
 import io.atomix.catalyst.transport.Address
+import io.atomix.copycat.server.CopycatServer
 import io.mediachain.copycat.{Server, Transport}
 import io.mediachain.datastore.{PersistentDatastore, DynamoDatastore}
+import scala.io.StdIn
 import scala.collection.JavaConversions._
 import sys.process._
 
 object JournalServer {
   def main(args: Array[String]) {
-    if (args.length < 1) {
-      println("Arguments: server-config-file [cluster-address ...]")
-      System.exit(1)
-    }
-    
-    val propfile = args.head
-    val cluster = args.tail.toList
+    val (interactive, config, cluster) = parseArgs(args)
     val props = new Properties
-    props.load(new FileInputStream(propfile))
-    run(props, cluster)
+    props.load(new FileInputStream(config))
+    run(interactive, props, cluster)
   }
   
-  def run(conf: Properties, cluster: List[String]) {
+  def parseArgs(args: Array[String]) = {
+    args match {
+      case Array("-i", config, cluster@_*) =>
+        (true, config, cluster.toList)
+      case Array(config, cluster@_*) =>
+        (false, config, cluster.toList)
+      case _ =>
+        throw new RuntimeException("Expected arguments: [-i] config [cluster-address ...]")
+    }
+  }
+  
+  def run(interactive: Boolean, conf: Properties, cluster: List[String]) {
     def getq(key: String): String =
       getopt(key).getOrElse {throw new RuntimeException("Missing configuration property: " + key)}
     
@@ -50,11 +57,45 @@ object JournalServer {
     val server = Server.build(address, copycatdir, datastore, sslConfig)
     
     if (cluster.isEmpty) {
-      server.bootstrap().join()
+      server.bootstrap.join()
     } else {
       server.join(cluster.map {addr => new Address(addr)}).join()
     }
     
+    if (interactive) {
+      println("Running with interactive console")
+      interactiveLoop(server)
+    } else {
+      serverLoop(server)
+    }
+    datastore.close()
+  }
+  
+  def serverLoop(server: CopycatServer) {
     while (server.isRunning) {Thread.sleep(1000)}
+  }
+
+  def interactiveLoop(server: CopycatServer) {
+    print("> ")
+    val next = StdIn.readLine()
+    if (next != null) {
+      val cmd = next.trim
+      cmd match {
+        case "shutdown" =>
+          println("shutting down")
+          server.shutdown.join()
+        case "leave" =>
+          println("leaving cluster")
+          server.leave.join()
+        case "" =>
+          interactiveLoop(server)
+        case what =>
+          println(s"Unknown command ${what}; I only understand shutdown and leave")
+          interactiveLoop(server)
+      }
+    } else {
+      // stdin closed; shutdown
+      server.shutdown.join()
+    }
   }
 }


### PR DESCRIPTION
- Log the queue backlog when backing off in dynamo to help tune dynamo provisioning
- Add a simple interactive control loop for screened JournalServers, so that we can cleanly shutdown or retire a server
