### PR TITLE
Make original metadata reference in records a first-class citizen

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/CborSerialization.scala
@@ -312,10 +312,11 @@ object CborSerialization {
     def toCMapWithMeta(
       defaults: Map[String, CValue],
       optionals: Map[String, Option[CValue]],
-      meta: Map[String, CValue])
+      meta: Map[String, CValue],
+      metaSource: Option[Reference])
     : CMap =
       toCMapWithDefaults(defaults + ("meta" -> CMap.withStringKeys(meta.toList)),
-                         optionals)
+                         optionals + ("metaSource" -> metaSource.map(_.toCbor)))
     
   }
 
@@ -373,7 +374,8 @@ object CborSerialization {
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.Entity)
         meta <- getRequired[CMap](cMap, "meta")
-      } yield Entity(meta.asStringKeyedMap)
+      } yield Entity(meta.asStringKeyedMap, 
+                     getOptionalReference(cMap, "metaSource"))
   }
 
   object ArtefactDeserializer extends CborDeserializer[Artefact]
@@ -382,7 +384,8 @@ object CborSerialization {
       for {
         _ <- assertRequiredTypeName(cMap, MediachainTypes.Artefact)
         meta <- getRequired[CMap](cMap, "meta")
-      } yield Artefact(meta.asStringKeyedMap)
+      } yield Artefact(meta.asStringKeyedMap,
+                       getOptionalReference(cMap, "metaSource"))
   }
 
   object ArtefactChainCellDeserializer extends CborDeserializer[ArtefactChainCell]
@@ -395,7 +398,8 @@ object CborSerialization {
       } yield ArtefactChainCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = meta.asStringKeyedMap
+        meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource")
       )
   }
 
@@ -409,7 +413,8 @@ object CborSerialization {
       } yield ArtefactUpdateCell(
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
-        meta = meta.asStringKeyedMap
+        meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource")
       )
   }
 
@@ -425,6 +430,7 @@ object CborSerialization {
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource"),
         artefactLink = artefactLink
       )
   }
@@ -441,6 +447,7 @@ object CborSerialization {
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource"),
         entity = entity
       )
   }
@@ -457,6 +464,7 @@ object CborSerialization {
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource"),
         artefactLink = artefactLink
       )
   }
@@ -473,6 +481,7 @@ object CborSerialization {
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource"),
         entity = entity
       )
   }
@@ -488,6 +497,7 @@ object CborSerialization {
         artefact = artefact,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource"),
         entity = getOptionalReference(cMap, "entity")
       )
   }
@@ -502,7 +512,8 @@ object CborSerialization {
       } yield EntityChainCell(
         entity = entity,
         chain = getOptionalReference(cMap, "chain"),
-        meta = meta.asStringKeyedMap
+        meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource")
       )
   }
 
@@ -516,7 +527,8 @@ object CborSerialization {
       } yield EntityUpdateCell(
         entity = entity,
         chain = getOptionalReference(cMap, "chain"),
-        meta = meta.asStringKeyedMap
+        meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource")
       )
   }
 
@@ -532,6 +544,7 @@ object CborSerialization {
         entity = entity,
         chain = getOptionalReference(cMap, "chain"),
         meta = meta.asStringKeyedMap,
+        metaSource = getOptionalReference(cMap, "metaSource"),
         entityLink = entityLink
       )
   }

--- a/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/CborSerializationSpec.scala
@@ -57,6 +57,7 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
         c.entity must_== expected.entity
         c.chain must_== expected.chain
         c.meta must havePairs(expected.meta.toList:_*)
+        c.metaSource must_== expected.metaSource
       }
     }
 
@@ -66,6 +67,7 @@ object CborSerializationSpec extends BaseSpec with ScalaCheck {
         c.artefact must_== expected.artefact
         c.chain must_== expected.chain
         c.meta must havePairs(expected.meta.toList:_*)
+        c.metaSource must_== expected.metaSource
       }
     }
 

--- a/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
+++ b/protocol/src/test/scala/io/mediachain/protocol/DataObjectGenerators.scala
@@ -45,8 +45,10 @@ object DataObjectGenerators {
 
   val genNilReference: Gen[Option[Reference]] = Gen.const(None)
 
-  val genEntity: Gen[Entity] = genMeta.map(Entity)
-  val genArtefact: Gen[Artefact] = genMeta.map(Artefact)
+  val genMetaSource = genOptionalReference
+
+  val genEntity: Gen[Entity] = genMeta.map(meta => Entity(meta))
+  val genArtefact: Gen[Artefact] = genMeta.map(meta => Artefact(meta))
 
   def genReferenceFor(canonicalGen: Gen[CanonicalRecord]): Gen[Reference] =
     canonicalGen.map(MultihashReference.forDataObject)
@@ -55,7 +57,7 @@ object DataObjectGenerators {
     entityGen: Gen[Entity],
     chainGen: Gen[Option[Reference]]
   ): Gen[EntityChainCell] =
-    (genReferenceFor(entityGen) |@| chainGen |@| genMeta)
+    (genReferenceFor(entityGen) |@| chainGen |@| genMeta |@| genMetaSource)
       .map(EntityChainCell.apply)
 
   val genEntityChainCell: Gen[EntityChainCell] = genEntityChainCell(genEntity, genOptionalReference)
@@ -64,7 +66,7 @@ object DataObjectGenerators {
     artefactGen: Gen[Artefact],
     chainGen: Gen[Option[Reference]]
   ): Gen[ArtefactChainCell] =
-    (genReferenceFor(artefactGen) |@| chainGen |@| genMeta)
+    (genReferenceFor(artefactGen) |@| chainGen |@| genMeta |@| genMetaSource)
       .map(ArtefactChainCell.apply)
 
   val genArtefactChainCell: Gen[ArtefactChainCell] = genArtefactChainCell(genArtefact, genOptionalReference)
@@ -73,7 +75,7 @@ object DataObjectGenerators {
     entityGen: Gen[Entity],
     chainGen: Gen[Option[Reference]]
   ) = genEntityChainCell(entityGen, chainGen).map { base =>
-    EntityUpdateCell(base.entity, base.chain, base.meta)
+    EntityUpdateCell(base.entity, base.chain, base.meta, base.metaSource)
   }
 
   val genEntityUpdateCell: Gen[EntityUpdateCell] =
@@ -86,7 +88,7 @@ object DataObjectGenerators {
   ) = for {
     base <- genEntityChainCell(entityGen, chainGen)
     entityLink <- entityLinkGen
-  } yield EntityLinkCell(base.entity, base.chain, base.meta, entityLink)
+  } yield EntityLinkCell(base.entity, base.chain, base.meta, base.metaSource, entityLink)
   val genEntityLinkCell: Gen[EntityLinkCell] =
     genEntityLinkCell(genEntity, genOptionalReference, genReference)
 
@@ -94,7 +96,7 @@ object DataObjectGenerators {
     artefactGen: Gen[Artefact],
     chainGen: Gen[Option[Reference]]
   ) = genArtefactChainCell(artefactGen, chainGen).map { base =>
-    ArtefactUpdateCell(base.artefact, base.chain, base.meta)
+    ArtefactUpdateCell(base.artefact, base.chain, base.meta, base.metaSource)
   }
   val genArtefactUpdateCell: Gen[ArtefactUpdateCell] =
     genArtefactUpdateCell(genArtefact, genOptionalReference)
@@ -106,7 +108,7 @@ object DataObjectGenerators {
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     artefactLink <- artefactLinkGen
-  } yield ArtefactLinkCell(base.artefact, base.chain, base.meta, artefactLink)
+  } yield ArtefactLinkCell(base.artefact, base.chain, base.meta, base.metaSource, artefactLink)
   val genArtefactLinkCell: Gen[ArtefactLinkCell] =
     genArtefactLinkCell(genArtefact, genOptionalReference, genReference)
 
@@ -117,7 +119,7 @@ object DataObjectGenerators {
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- entityGen
-  } yield ArtefactCreationCell(base.artefact, base.chain, base.meta, entity)
+  } yield ArtefactCreationCell(base.artefact, base.chain, base.meta, base.metaSource, entity)
   val genArtefactCreationCell: Gen[ArtefactCreationCell] =
     genArtefactCreationCell(genArtefact, genOptionalReference, genReference)
 
@@ -128,7 +130,7 @@ object DataObjectGenerators {
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     artefactOrigin <- artefactOriginGen
-  } yield ArtefactDerivationCell(base.artefact, base.chain, base.meta, artefactOrigin)
+  } yield ArtefactDerivationCell(base.artefact, base.chain, base.meta, base.metaSource, artefactOrigin)
   val genArtefactDerivationCell: Gen[ArtefactDerivationCell] =
     genArtefactDerivationCell(genArtefact, genOptionalReference, genReference)
 
@@ -139,7 +141,7 @@ object DataObjectGenerators {
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- entityGen
-  } yield ArtefactOwnershipCell(base.artefact, base.chain, base.meta, entity)
+  } yield ArtefactOwnershipCell(base.artefact, base.chain, base.meta, base.metaSource, entity)
   val genArtefactOwnershipCell: Gen[ArtefactOwnershipCell] =
     genArtefactOwnershipCell(genArtefact, genOptionalReference, genReference)
 
@@ -150,7 +152,7 @@ object DataObjectGenerators {
   ) = for {
     base <- genArtefactChainCell(artefactGen, chainGen)
     entity <- entityGen
-  } yield ArtefactReferenceCell(base.artefact, base.chain, base.meta, entity)
+  } yield ArtefactReferenceCell(base.artefact, base.chain, base.meta, base.metaSource, entity)
   val genArtefactReferenceCell: Gen[ArtefactReferenceCell] =
     genArtefactReferenceCell(genArtefact, genOptionalReference, genOptionalReference)
 

--- a/rfc/mediachain-rfc-1.md
+++ b/rfc/mediachain-rfc-1.md
@@ -66,7 +66,9 @@ their type field set to `entity`, while Artefacts are instances
 of data objects with their type set to `artefact`. Both can contain
 arbitrary metadata in the form of key values pairs stored in a `meta`
 field. At a minimum both contain a `name` metadata field, while artefacts
-also carry optional `description` and creation data fields.
+also carry optional `description` and creation data fields. When the
+object metadata have been ingested from an external dataset,
+the original unparsed metadata are linked through a `metaSource` reference.
 
 Artefacts can also have their associated data stored in IPFS, so that media
 can be directly accessed from references to their Canonicals.
@@ -88,6 +90,7 @@ Entity = {
   "name" : <String>
   <Key> : <Value> ... ; entity metadata
   }
+ ["metaSource": <Reference>]
  }
 
 Artefact = {
@@ -100,6 +103,7 @@ Artefact = {
   ["description" : <String>]
   <Key> : <Value> ... ; artefact metadata
   }
+ ["metaSource": <Reference>]
  }
 
 Reference = {
@@ -185,6 +189,7 @@ EntityUpdateCell = {
  "meta" : {
    <Key> : <Value> ... ; metadata updates
   }
+ ["metaSource": <Reference>]
  }
 
 EntityLinkCell = {
@@ -196,6 +201,7 @@ EntityLinkCell = {
  "meta" : {
   <Key> : <Value> ... ; entity relationship metadata
   }
+ ["metaSource": <Reference>]
  }
 
 ArtefactChainCell =
@@ -215,6 +221,7 @@ ArtefactUpdateCell = {
  "meta" : {
   <Key> : <Value> ... ; metadata updates
   }
+ ["metaSource": <Reference>]
  }
 
 ArtefactLinkCell = {
@@ -226,6 +233,7 @@ ArtefactLinkCell = {
  "meta" : {
   <Key> : <Value> ... ; artefact relationship metadata
   }
+ ["metaSource": <Reference>]
  }
 
 ArtefactCreationCell = {
@@ -237,6 +245,7 @@ ArtefactCreationCell = {
  "meta" : {
   <Key> : <Value> ... ; creation metadata
   }
+ ["metaSource": <Reference>]
  }
 
 ArtefactDerivationCell = {
@@ -248,6 +257,7 @@ ArtefactDerivationCell = {
  "meta" : {
   <Key> : <Value> ... ; derivation metadata
   }
+ ["metaSource": <Reference>]
  }
 
 ArtefactOwnershipCell = {
@@ -259,6 +269,7 @@ ArtefactOwnershipCell = {
  "meta" : {
   <Key> : <Value> ... ; IP ownership metadata
   }
+ ["metaSource": <Reference>]
  }
 
 ArtefactReferenceCell = {
@@ -271,6 +282,7 @@ ArtefactReferenceCell = {
   ["url" : <URL>]
   <Key> : <Value> ... ; reference metadata
   }
+ ["metaSource": <Reference>]
  }
 ```
 

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -102,7 +102,7 @@ object StateMachine {
         case None => commitError("invalid reference")
         case Some(cref) => {
           (cref, cell) match {
-            case (EntityChainReference(chain), EntityChainCell(entity, xchain, meta)) => {
+            case (EntityChainReference(chain), EntityChainCell(entity, xchain, _, _)) => {
               if (checkUpdate(ref, chain, entity, xchain)) {
                 val newcell = cell.cons(chain)
                 val newchain = datastore.put(newcell)
@@ -110,7 +110,7 @@ object StateMachine {
                 commit(ref, newchain, chain)
               } else commitError("invalid chain cell")
             }
-            case (ArtefactChainReference(chain), ArtefactChainCell(artefact, xchain, meta)) => {
+            case (ArtefactChainReference(chain), ArtefactChainCell(artefact, xchain, _, _)) => {
               if (checkUpdate(ref, chain, artefact, xchain)) {
                 val newcell = cell.cons(chain)
                 val newchain = datastore.put(newcell)

--- a/transactor/src/test/scala/io/mediachain/copycat/CopycatSerializerSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/CopycatSerializerSpec.scala
@@ -44,8 +44,9 @@ object CopycatSerializerSpec extends BaseSpec {
 
   def journalUpdateRoundTrip = {
     val meta = Map("foo" -> CMap(CString("bar") -> CString("baz")))
+    val metaSource = Some(randomRef)
     val ref = randomRef
-    val update = JournalUpdate(ref, EntityUpdateCell(ref, None, meta))
+    val update = JournalUpdate(ref, EntityUpdateCell(ref, None, meta, metaSource))
 
     roundTrip(update, new JournalUpdateSerializer)
   }


### PR DESCRIPTION
Adds a metaSource field to the Record data model so that they can be tracked by the mediachain as first class objects. 
#116 This allows us to back them up together with the block with a backing store client.
