### PR TITLE
vagrant / ansible setup and unified command line parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ private
 # ignore test datasets for translation engine
 translation_engine/test-resources/datasets/*
 !translation_engine/test-resources/datasets/README.md
+
+.vagrant
+*.retry

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,39 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # Use a box compatible with both virtualbox and vmware_fusion providers
+  config.vm.box = "phusion/ubuntu-14.04-amd64"
+
+  # Forward transactor rpc service port 10001
+  config.vm.network "forwarded_port", guest: 10001, host: 10001
+  
+  # Forward port for local dynamodb (for development)
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
+
+  # Forward jvm debugger port 5005 on the guest to 5006 on the host
+  config.vm.network "forwarded_port", guest: 5005, host: 5006
+
+  # Set ram, etc for vm providers
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "2048"
+  end
+
+  config.vm.provider "vmware_fusion" do |vm|
+    vm.memory = "2048"
+  end
+
+  # Set hostname for vm
+  config.vm.define "transactor"
+
+  # Ansible config
+  config.vm.provision :ansible do |ansible|
+    ansible.limit = "transactors"
+    ansible.playbook = "meta/dev.yml"
+    ansible.groups = { "transactors" => ["transactor"] }
+  end
+end

--- a/meta/dev.yml
+++ b/meta/dev.yml
@@ -1,0 +1,6 @@
+---
+- hosts: transactors
+  roles:
+    - { role: jpnewman.java, tags: ["init"], become: yes, become_user: "root" }
+    - { role: milinda.sbt, become: yes, become_user: "root" }
+    - { role: dynamodb_local, become: yes, become_user: "root" }

--- a/meta/roles/dynamodb_local/defaults/main.yml
+++ b/meta/roles/dynamodb_local/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+dynamodb_version: "2016-05-17"
+dynamodb_sha: "832d474316c9d092de8c24885e69c9be9e22b9807e7383e0de6f247e44601a90"
+dynamodb_port: "8000"

--- a/meta/roles/dynamodb_local/handlers/main.yml
+++ b/meta/roles/dynamodb_local/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: "Restart DynamoDB"
+  service: >
+    name=dynamodb
+    state=restarted

--- a/meta/roles/dynamodb_local/meta/main.yml
+++ b/meta/roles/dynamodb_local/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: Cole Brown <cole.brown@gmail.com>
+  description: Installs the development version of the Amazon DynamoDB server
+  company: Mediachain Labs
+  license: MIT
+  min_ansible_version: 1.8.1
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+  categories:
+    - development
+    - database
+    - database:nosql
+dependencies:
+  - role: jpnewman.java

--- a/meta/roles/dynamodb_local/tasks/main.yml
+++ b/meta/roles/dynamodb_local/tasks/main.yml
@@ -1,0 +1,38 @@
+- name: "Create dynamo directory"
+  file:
+      path="/opt/dynamodb"
+      state="directory"
+
+- name: "Download the DynamoDB local jar"
+  get_url:
+    url="http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_{{dynamodb_version}}.tar.gz"
+    sha256sum="{{dynamodb_sha}}"
+    dest=/opt/dynamodb/
+  notify:
+   - Restart DynamoDB
+  register: dynamodb_download
+
+- name: "Install DynamoDB in /opt/dynamodb"
+  shell: |
+    tar -zxf ./dynamodb_local_{{ dynamodb_version }}.tar.gz
+    chdir="/opt/dynamodb"
+
+  when: dynamodb_download.changed
+
+- name: "Drop an init.d file for DynamoDB"
+  template: >
+    src=dynamodb.init.sh.j2
+    dest=/etc/init.d/dynamodb
+    mode=0700
+    owner=root
+    group=root
+  notify:
+    - Restart DynamoDB
+
+- name: "Make sure DynamoDB local development is running"
+  service: >
+    name=dynamodb
+    state=running
+    enabled=yes
+    runlevel=5
+    pattern="DynamoDBLocal.jar"

--- a/meta/roles/dynamodb_local/templates/dynamodb.init.sh.j2
+++ b/meta/roles/dynamodb_local/templates/dynamodb.init.sh.j2
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# chkconfig: 35 99 99
+# description: DynamoDB
+### END INIT INFO
+
+# Amount of memory for Java
+JAVAMEM=256M
+
+# Location of dynamodb files
+LOCATION="/opt/dynamodb"
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+NAME="dynamodb"
+DAEMON="$(which java)"
+ARGS="-Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar --port {{ dynamodb_port }}"
+JAR_NAME="DynamoDBLocal.jar"
+
+LOGFILE="/opt/dynamodb/dynamodb.log"
+PID_FILE="/var/run/dynamodb.pid"
+
+# Exit if the package is not installed
+if [ ! -x "$DAEMON" ]; then
+  echo "Couldn't find $DAEMON"
+  exit 99
+fi
+
+ACTION="${1}"
+
+run_action() {
+    echo -n "${1}"
+
+    if
+        ${2} &> /dev/null
+    then
+        RETVAL=${?}
+        echo " [OK]"
+    else
+        RETVAL=${?}
+        echo " [NG]"
+        echo "${3}"
+    fi
+
+    return ${RETVAL}
+}
+
+start_daemon() {
+    cd $LOCATION && \
+      ($DAEMON $ARGS >> ${LOGFILE} 2>&1 & echo $! > ${PID_FILE})
+    return ${?}
+}
+
+get_pid() {
+    PID="$(cat ${PID_FILE} 2> /dev/null)"
+}
+
+get_status() {
+    get_pid
+
+    IS_ALIVE=0
+
+    kill -0 ${PID} &> /dev/null
+
+    if
+        [ ${?} -eq 0 ]
+    then
+        IS_ALIVE=1
+    fi
+}
+
+do_status() {
+    get_status
+
+    if
+        [ "${PID}" == "" ]
+    then
+        echo "${NAME} is not running"
+        RETVAL=1
+    elif
+        [ "${IS_ALIVE}" == "0" ]
+    then
+        echo "${NAME} is dead (pid: ${PID})"
+        RETVAL=2
+    else
+        echo "${NAME} is running (pid: ${PID})"
+    fi
+}
+
+do_start() {
+    get_status
+
+    if
+        [ "${PID}" != "" ] && [ "${IS_ALIVE}" == "0" ]
+    then
+        echo "${NAME} seems dead (pid: ${PID}), please check that the server is healthy"
+    fi
+
+    if
+        [ "${PID}" == "" ] || [ "${IS_ALIVE}" == "0" ]
+    then
+        run_action "Starting ${NAME}: " \
+            "start_daemon" \
+            "Starting ${NAME} failed. Please check ${LOG_FILE} for more info";
+
+        RETVAL=$?
+    else
+        echo "${NAME} is already running"
+        RETVAL=1
+    fi
+}
+
+do_stop() {
+    get_status
+
+    if
+        [ "${IS_ALIVE}" == "0" ]
+    then
+        echo "${NAME} is not running"
+        RETVAL=1
+    else
+        run_action "Stopping ${NAME} (pid: ${PID})" \
+            "kill ${PID}" \
+            "Could not stop ${NAME}"
+
+        RETVAL=${?}
+
+        [ ${RETVAL} -eq 0 ] && rm -f ${PID_FILE}
+    fi
+}
+
+case "${ACTION}" in
+    "start")
+            do_start
+            ;;
+    "stop")
+            do_stop
+            ;;
+    "restart")
+            do_stop
+            do_start
+            ;;
+    "status")
+            do_status
+            ;;
+    *)
+            echo "Usage: ${0} {start|stop|restart|status}"
+            RETVAL=1
+esac
+
+exit ${RETVAL}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -52,7 +52,8 @@ object MediachainBuild extends Build {
         "org.slf4j" % "slf4j-api" % "1.7.21",
         "org.slf4j" % "slf4j-simple" % "1.7.21",
         "org.rocksdb" % "rocksdbjni" % "4.5.1",
-        "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.74"
+        "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.74",
+        "com.github.scopt" %% "scopt" % "3.4.0"
       ),
       assemblyMergeStrategy in assembly := {
         case "META-INF/io.netty.versions.properties" => 
@@ -60,7 +61,8 @@ object MediachainBuild extends Build {
         case x => 
           val oldStrategy = (assemblyMergeStrategy in assembly).value
           oldStrategy(x)
-      }
+      },
+      mainClass := Some("io.mediachain.transactor.Main")
     ))
     .dependsOn(protocol)
     .dependsOn(scalaMultihash)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,7 +18,8 @@ object MediachainBuild extends Build {
       "-feature", "-language:higherKinds"),
     // resolvers += Resolver.mavenLocal, // local maven for tip debugging
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats" % "0.4.1",
+      "org.typelevel" %% "cats" % "0.6.0",
+      "org.typelevel" %% "dogs-core" % "0.2.2",
       "org.json4s" %% "json4s-jackson" % "3.3.0",
       "org.specs2" %% "specs2-core" % specs2Version % "test",
       "org.specs2" %% "specs2-junit" % specs2Version % "test",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,7 +38,7 @@ object MediachainBuild extends Build {
     .settings(settings)
 
   // TODO: replace this with maven-published version
-  val scalaMultihashCommit = "f8ddda5c98ff0d73fdcadfc8a66332cb22f9c23b"
+  val scalaMultihashCommit = "b2999d6c00b3acab6ea3ff5d0965634bed3a3823"
   lazy val scalaMultihash = RootProject(uri(
     s"git://github.com/mediachain/scala-multihash.git#$scalaMultihashCommit"
   ))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,7 +18,7 @@ object MediachainBuild extends Build {
       "-feature", "-language:higherKinds"),
     // resolvers += Resolver.mavenLocal, // local maven for tip debugging
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats" % "0.6.0",
+      "org.typelevel" %% "cats" % "0.4.1",
       "org.typelevel" %% "dogs-core" % "0.2.2",
       "org.json4s" %% "json4s-jackson" % "3.3.0",
       "org.specs2" %% "specs2-core" % specs2Version % "test",
@@ -103,7 +103,6 @@ object MediachainBuild extends Build {
   // schema translator/ingester (candidate to spin out into own project)
   lazy val translation_engine = Project("translation_engine", file("translation_engine")).settings(settings ++ List(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats" % "0.4.1",
       "org.json4s" %% "json4s-jackson" % "3.3.0"
     ),
     unmanagedClasspath in Test += baseDirectory.value / "test-resources"
@@ -121,7 +120,6 @@ object MediachainBuild extends Build {
   lazy val core = Project("core", file("core")).settings(settings ++ List(
     libraryDependencies ++= Seq(
       "com.michaelpollmeier" % "gremlin-scala_2.11" % "3.1.1-incubating.1",
-      "org.typelevel" %% "cats" % "0.4.1",
       "org.json4s" %% "json4s-jackson" % "3.3.0"
     )
   ))
@@ -143,7 +141,6 @@ object MediachainBuild extends Build {
       "com.michaelpollmeier" % "gremlin-scala_2.11" % "3.1.1-incubating.1",
       "com.michaelpollmeier" % "orientdb-gremlin" % "3.1.0-incubating.1",
       "com.tinkerpop.blueprints" % "blueprints-core" % "2.6.0",
-      "org.typelevel" %% "cats" % "0.4.1",
       "com.chuusai" %% "shapeless" % "2.2.5",
       "org.json4s" %% "json4s-jackson" % "3.2.11",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.4.0",

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -16,7 +16,6 @@ message UpdateRequest {
 
 message JournalStreamRequest {
     MultihashReference lastJournalBlock = 1;
-    string offset = 2;
 }
 
 message UpdateChainResult {

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -16,6 +16,7 @@ message UpdateRequest {
 
 message JournalStreamRequest {
     MultihashReference lastJournalBlock = 1;
+    string offset = 2;
 }
 
 message UpdateChainResult {

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -15,7 +15,7 @@ message UpdateRequest {
 }
 
 message JournalStreamRequest {
-    int64 offset = 1;
+    MultihashReference lastJournalBlock = 1;
 }
 
 message ChainUpdateDescription {
@@ -24,10 +24,11 @@ message ChainUpdateDescription {
 }
 
 message JournalEvent {
-    int64 journalIndex = 1;
+    uint64 journalIndex = 1;
     oneof event {
         MultihashReference canonicalInserted = 2;
         ChainUpdateDescription chainUpdated = 3;
+        MultihashReference journalBlockPublished = 4;
     }
 }
 

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -24,7 +24,6 @@ message ChainUpdateDescription {
 }
 
 message JournalEvent {
-    uint64 journalIndex = 1;
     oneof event {
         MultihashReference canonicalInserted = 2;
         ChainUpdateDescription chainUpdated = 3;

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -19,9 +19,9 @@ message JournalStreamRequest {
 }
 
 message UpdateChainResult {
-    MultihashReference canonicalRef = 1;
-    MultihashReference chainHeadRef = 2;
-    MultihashReference chainPreviousHeadRef = 3;
+    MultihashReference canonical = 1;
+    MultihashReference chain = 2;
+    MultihashReference chainPrevious = 3;
 }
 
 message JournalEvent {
@@ -42,7 +42,7 @@ service TransactorService {
     rpc LookupChain(MultihashReference) returns
         (MultihashReference);
 
-    rpc StreamJournalUpdates(JournalStreamRequest) returns
+    rpc JournalStream(JournalStreamRequest) returns
         (stream JournalEvent);
 }
 

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -14,14 +14,34 @@ message UpdateRequest {
     bytes chainCellCbor = 1;
 }
 
+message JournalStreamRequest {
+    int64 offset = 1;
+}
+
+message ChainUpdateDescription {
+    MultihashReference canonicalRef = 1;
+    MultihashReference chainHeadRef = 2;
+}
+
+message JournalEvent {
+    int64 journalIndex = 1;
+    oneof event {
+        MultihashReference canonicalInserted = 2;
+        ChainUpdateDescription chainUpdated = 3;
+    }
+}
+
 service TransactorService {
     rpc InsertCanonical(InsertRequest) returns
         (MultihashReference);
 
     rpc UpdateChain(UpdateRequest) returns
-        (MultihashReference);
+        (ChainUpdateDescription);
 
     rpc LookupChain(MultihashReference) returns
         (MultihashReference);
+
+    rpc StreamJournalUpdates(JournalStreamRequest) returns
+        (stream JournalEvent);
 }
 

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -18,15 +18,16 @@ message JournalStreamRequest {
     MultihashReference lastJournalBlock = 1;
 }
 
-message ChainUpdateDescription {
+message UpdateChainResult {
     MultihashReference canonicalRef = 1;
     MultihashReference chainHeadRef = 2;
+    MultihashReference chainPreviousHeadRef = 3;
 }
 
 message JournalEvent {
     oneof event {
         MultihashReference canonicalInserted = 2;
-        ChainUpdateDescription chainUpdated = 3;
+        UpdateChainResult chainUpdated = 3;
         MultihashReference journalBlockPublished = 4;
     }
 }
@@ -36,7 +37,7 @@ service TransactorService {
         (MultihashReference);
 
     rpc UpdateChain(UpdateRequest) returns
-        (ChainUpdateDescription);
+        (MultihashReference);
 
     rpc LookupChain(MultihashReference) returns
         (MultihashReference);

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -1,14 +1,19 @@
 package io.mediachain.protocol
 
-
 object Datastore {
   import io.mediachain.multihash.MultiHash
   import io.mediachain.protocol.CborSerialization._
   import io.mediachain.protocol.Transactor.{ArtefactChainReference, ChainReference, EntityChainReference}
   import io.mediachain.util.cbor.CborAST._
   import scala.util.Try
+  import dogs.Streaming
+  import cats.Eval
 
-  // Datastore interface
+  /** Datastore interface.
+    *
+    * Implementations of this must be thread-safe
+    *
+    */
   trait Datastore {
     def get(ref: Reference): Option[DataObject]
     def put(obj: DataObject): Reference
@@ -353,6 +358,20 @@ object Datastore {
       val defaults = Map("index" -> CInt(index), "entries" -> cborEntries)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithDefaults(defaults, optionals)
+    }
+
+    def toStream(datastore: Datastore): Streaming[JournalBlock] = {
+      val next: Eval[Streaming[JournalBlock]] = chain match {
+        case Some(ref) => Eval.always {
+          datastore.get(ref) match {
+            case Some(x: JournalBlock) => x.toStream(datastore)
+            case _ => Streaming.empty
+          }
+        }
+        case _ => Eval.now(Streaming.empty)
+      }
+
+      Streaming.cons[JournalBlock](this, next)
     }
   }
 }

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -89,12 +89,12 @@ class TransactorService(client: Client,
   }
   
   override def updateChain(request: UpdateRequest)
-  : Future[ChainUpdateDescription] = {
+  : Future[Transactor.MultihashReference] = {
     val bytes = request.chainCellCbor.toByteArray
     checkRecordSize(bytes)
-    
-    val cellXor = CborSerialization.fromCborBytes[ChainCell](bytes)      
-    
+
+    val cellXor = CborSerialization.fromCborBytes[ChainCell](bytes)
+
     val updateF = cellXor match {
       case Xor.Left(err) => throw new StatusRuntimeException(
         Status.INVALID_ARGUMENT.withDescription(
@@ -113,11 +113,8 @@ class TransactorService(client: Client,
               s"Journal Error: $err"
             )
           )
-        case Xor.Right(entry) => {
-          ChainUpdateDescription()
-            .withCanonicalRef(refToRPCMultihashRef(entry.ref))
-            .withChainHeadRef(refToRPCMultihashRef(entry.chain))
-        }
+        case Xor.Right(entry) =>
+          refToRPCMultihashRef(entry.chain)
       }
     }
   }
@@ -173,7 +170,7 @@ class TransactorService(client: Client,
 
       case ChainEntry(_, ref, chain, _) =>
         Event.ChainUpdated(
-          ChainUpdateDescription()
+          UpdateChainResult()
             .withCanonicalRef(refToRPCMultihashRef(ref))
             .withChainHeadRef(refToRPCMultihashRef(chain))
         )

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -17,7 +17,7 @@ import io.mediachain.protocol.transactor.Transactor
 import io.mediachain.protocol.transactor.Transactor.JournalEvent.Event.JournalBlockPublished
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.collection.mutable.{Queue => MQueue}
 

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -123,7 +123,7 @@ class TransactorService(client: Client,
   import collection.mutable.{Set => MSet}
   private val journalEventObservers: MSet[StreamObserver[JournalEvent]] = MSet()
 
-  override def streamJournalUpdates(request: JournalStreamRequest,
+  override def journalStream(request: JournalStreamRequest,
     responseObserver: StreamObserver[JournalEvent]): Unit = {
 
     // TODO: play event stream following lastBlockRef in request.
@@ -168,11 +168,11 @@ class TransactorService(client: Client,
       case CanonicalEntry(_, ref) =>
         Event.CanonicalInserted(refToRPCMultihashRef(ref))
 
-      case ChainEntry(_, ref, chain, _) =>
+      case ChainEntry(_, ref, chain, chainPrevious) =>
         Event.ChainUpdated(
-          UpdateChainResult()
-            .withCanonicalRef(refToRPCMultihashRef(ref))
-            .withChainHeadRef(refToRPCMultihashRef(chain))
+          UpdateChainResult(chainPrevious = chainPrevious.map(refToRPCMultihashRef))
+            .withCanonical(refToRPCMultihashRef(ref))
+            .withChain(refToRPCMultihashRef(chain))
         )
     }
     publishEvent(event)

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -193,6 +193,7 @@ class TransactorListener(executor: ExecutorService,
             // if the client killed the connection, remove the observer
             cancelledObservers.add(observer)
           case t: Throwable =>
+            logger.error(s"Exception when publishing event: $t")
             throw t
         }
       }

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -53,13 +53,12 @@ class BackfillRunner(offset: Reference,
     Streaming.cons(Some(head), chain)
       .takeWhile(x => x.isDefined && !x.contains(offset))
       .iterator
-      .foreach {
-        case Some(x) =>
-          val event = JournalEvent(
-            JournalBlockPublished(refToRPCMultihashRef(x))
-          )
-          observer.onNext(event)
-        case _ => ()
+      .collect { case Some(ref) => ref }
+      .foreach { x =>
+        val event = JournalEvent(
+          JournalBlockPublished(refToRPCMultihashRef(x))
+        )
+        observer.onNext(event)
       }
 
     backfilled.set(true)

--- a/transactor/src/main/scala/io/mediachain/datastore/DynamoTableMaker.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/DynamoTableMaker.scala
@@ -1,0 +1,52 @@
+package io.mediachain.datastore
+
+object DynamoLocalTableMaker {
+  def main(args: Array[String]): Unit = {
+    val tableNameOpt = args.lift(0)
+    val endpointOpt = args.lift(1).orElse(Some("http://localhost:8000"))
+
+    println("setting up local dynamodb tables")
+    DynamoTableMaker.makeTables("", "", tableNameOpt, endpointOpt)
+  }
+}
+
+object DynamoTableMaker {
+  def makeTables(
+    accessKey: String,
+    secretKey: String,
+    baseTableName: Option[String] = None,
+    endpoint: Option[String] = None,
+    readThroughput: Long = 10,
+    writeThroughput: Long = 10
+  )
+  : Unit = {
+    import com.amazonaws.auth.BasicAWSCredentials
+    val awscreds = new BasicAWSCredentials(accessKey, secretKey)
+
+    import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+    val dynamo = endpoint match {
+      case Some(endpointUrl) =>
+        new AmazonDynamoDBClient(awscreds)
+          .withEndpoint(endpointUrl)
+          .asInstanceOf[AmazonDynamoDBClient]
+      case _ =>
+        new AmazonDynamoDBClient(awscreds)
+    }
+
+    import com.amazonaws.services.dynamodbv2.model._
+
+    import scala.collection.JavaConversions._
+
+    val baseTable = baseTableName.getOrElse("Mediachain")
+    val chunkTable = baseTable + "Chunks"
+    val mainTableAttrs = List(new AttributeDefinition("multihash", "S"))
+    val mainTableSchema = List(new KeySchemaElement("multihash", KeyType.HASH))
+    val pth = new ProvisionedThroughput(readThroughput, writeThroughput)
+    dynamo.createTable(mainTableAttrs, baseTable, mainTableSchema, pth)
+
+    val chunkTableAttrs = List(new AttributeDefinition("chunkId", "S"))
+    val chunkTableSchema = List(new KeySchemaElement("chunkId", KeyType.HASH))
+    dynamo.createTable(chunkTableAttrs, chunkTable, chunkTableSchema, pth)
+  }
+
+}

--- a/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
+++ b/transactor/src/main/scala/io/mediachain/datastore/PersistentDatastore.scala
@@ -2,9 +2,11 @@ package io.mediachain.datastore
 
 import java.util.Random
 import java.util.concurrent.LinkedBlockingDeque
+
 import com.amazonaws.AmazonClientException
 import org.slf4j.{Logger, LoggerFactory}
 import io.mediachain.multihash.MultiHash
+import io.mediachain.transactor.DynamoConfig
 
 class PersistentDatastore(config: PersistentDatastore.Config)
   extends BinaryDatastore with AutoCloseable with Runnable {
@@ -94,7 +96,7 @@ class PersistentDatastore(config: PersistentDatastore.Config)
 
 object PersistentDatastore {
   case class Config(
-    dynamo: DynamoDatastore.Config, 
+    dynamo: DynamoConfig,
     rocks: String,
     threads: Int = Runtime.getRuntime.availableProcessors
   )

--- a/transactor/src/main/scala/io/mediachain/transactor/Config.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Config.scala
@@ -1,0 +1,119 @@
+package io.mediachain.transactor
+
+import java.io.{File, FileInputStream}
+import java.util.Properties
+
+import io.mediachain.copycat.Transport.SSLConfig
+
+case class DynamoConfig(
+  baseTable: String,
+  endpoint: Option[Endpoint] = None
+)
+
+
+case class Endpoint(host: String, port: Int) {
+  def asString = s"$host:$port"
+}
+
+object Endpoint {
+  def apply(s: String): Endpoint = {
+    val parts = s.split(":")
+    Endpoint(parts(0), parts(1).toInt)
+  }
+}
+
+sealed trait RunMode
+case object TransactorMode extends RunMode
+case object FacadeMode extends RunMode
+
+
+case class Config(
+  mode: RunMode = null,
+  interactive: Boolean = false,
+  listenAddress: Endpoint = null,
+  clusterAddresses: Seq[Endpoint] = Seq(),
+  transactorDataDir: File = null,
+  sslConfig: Option[SSLConfig] = None,
+  dynamoConfig: DynamoConfig = DynamoConfig("Mediachain")
+)
+
+
+object Config {
+  import scopt._
+
+  val parser = new OptionParser[Config]("mediachain") {
+    head("mediachain")
+
+    opt[String]('l', "listen")
+      .required()
+      .text("bind address")
+      .valueName("<host:port>")
+      .action { (addrString, c) =>
+        c.copy(listenAddress = Endpoint(addrString))
+      }
+
+    opt[Seq[String]]('c', "cluster-addresses")
+      .text("addresses of transactor cluster members")
+      .valueName("<host1:port1>,<host2:port2>")
+      .action { (addrStrings, c) =>
+        c.copy(
+          clusterAddresses = addrStrings.map(Endpoint.apply)
+        )
+      }
+
+    opt[String]('t', "table-name")
+      .text("base name of dynamo-db table")
+      .action { (name, c) =>
+        c.copy(
+          dynamoConfig = c.dynamoConfig.copy(baseTable = name)
+        )
+      }
+
+    opt[File]('s', "ssl-properties")
+      .text("path to properties file for ssl configuration")
+      .action { (propsFile, c) =>
+        val props = new Properties
+        props.load(new FileInputStream(propsFile))
+        val sslConfig = SSLConfig.fromProperties(props).getOrElse(
+          throw new IllegalArgumentException("Unable to parse ssl config file")
+        )
+        c.copy(sslConfig = Some(sslConfig))
+      }
+
+    opt[String]('e', "dynamo-endpoint")
+      .text("endpoint for dynamo-db")
+      .action { (endpointString, c) =>
+        c.copy(
+          dynamoConfig = c.dynamoConfig.copy(endpoint =
+            Some(Endpoint(endpointString))
+          )
+        )
+      }
+
+    cmd("transactor").action { (_, c) =>
+      c.copy(mode = TransactorMode)
+    }.text("run the transactor")
+      .children(
+        opt[File]('d', "data")
+          .text("directory to store transactor data")
+          .required()
+          .action { (dir, c) =>
+            c.copy(
+              transactorDataDir = dir
+            )
+          },
+
+        opt[Unit]('i', "interactive")
+          .text("accept control commands from standard input")
+          .action { (_, c) =>
+            c.copy(interactive = true)
+          }
+      )
+
+    cmd("facade")
+      .text("run an RPC facade to the transactor cluster")
+      .action { (_, c) =>
+        c.copy(mode = FacadeMode)
+      }
+  }
+}

--- a/transactor/src/main/scala/io/mediachain/transactor/Entrypoints.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Entrypoints.scala
@@ -8,10 +8,9 @@ object Entrypoints {
   import io.mediachain.datastore.DynamoDatastore
   import com.amazonaws.auth.BasicAWSCredentials
 
-  private val datastoreConfig = DynamoDatastore.Config(
+  private val datastoreConfig = DynamoConfig(
     "Mediachain",
-    new BasicAWSCredentials("", ""),
-    Some("http://localhost:8000")
+    Some(Endpoint("localhost:8000"))
   )
 
   def startTransactorService(copycatAddr: String, listen: Int): Unit = {

--- a/transactor/src/main/scala/io/mediachain/transactor/Entrypoints.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Entrypoints.scala
@@ -1,0 +1,40 @@
+package io.mediachain.transactor
+
+/** These entrypoint functions serve as simple starters for running the system
+  * in a *development* environment.
+  *
+  */
+object Entrypoints {
+  def startTransactorService(copycatAddr: String, listen: Int): Unit = {
+    import io.mediachain.copycat.Client
+    import io.mediachain.copycat.TransactorService
+    import java.util.concurrent.Executors
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val client = Client.build()
+    client.connect(copycatAddr)
+
+    val service = new TransactorService(client)
+    val executor = Executors.newSingleThreadExecutor()
+
+    TransactorService.createServerThread(service, executor, listen)
+  }
+
+  def startCopycatService(listenAddr: String,
+                          logDir: String = "tmp"): Unit = {
+    import io.mediachain.copycat.Server
+    import io.mediachain.datastore.DynamoDatastore
+    import com.amazonaws.auth.BasicAWSCredentials
+
+    val datastoreConfig = DynamoDatastore.Config(
+      "Mediachain",
+      new BasicAWSCredentials("", ""),
+      Some("http://localhost:8000")
+    )
+    val datastore = new DynamoDatastore(datastoreConfig)
+    val server = Server.build(listenAddr, logDir, datastore)
+
+    server.bootstrap
+  }
+}
+

--- a/transactor/src/main/scala/io/mediachain/transactor/Main.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/Main.scala
@@ -1,0 +1,16 @@
+package io.mediachain.transactor
+
+object Main {
+
+  def main(args: Array[String]): Unit = {
+    Config.parser.parse(args, Config()) match {
+      case None => sys.exit(1)
+      case Some(c) =>
+        c.mode match {
+          case TransactorMode => JournalServer.run(c)
+          case FacadeMode => RpcService.run(c)
+        }
+    }
+  }
+
+}

--- a/transactor/src/main/scala/io/mediachain/transactor/RpcService.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/RpcService.scala
@@ -11,15 +11,15 @@ object RpcService {
 
   val logger = LoggerFactory.getLogger(RpcService.getClass)
 
-  def main(args: Array[String]) {
-    if (args.length < 2) {
-      println("arguments: rpc-service-port server-address ...")
-      sys.exit(1)
+  def run(config: Config) {
+    val rpcPort = config.listenAddress.port
+    val cluster = config.clusterAddresses.map(_.asString).toList
+
+    if (cluster.isEmpty) {
+      throw new IllegalArgumentException(
+        "No cluster address provided, can't start rpc service")
     }
 
-    val rpcPort = Integer.parseInt(args.head)
-    val cluster = args.tail.toList
-    
     val client = Client.build()
     logger.info(s"Connecting to cluster at $cluster...")
     client.connect(cluster)
@@ -27,13 +27,7 @@ object RpcService {
     implicit val ec = ExecutionContext.global
     // todo: dynamic
     val executor = Executors.newFixedThreadPool(4)
-    val datastoreConfig = DynamoDatastore.Config(
-      "Mediachain",
-      new BasicAWSCredentials("", ""),
-      Some("http://localhost:8000")
-    )
-    val datastore = new DynamoDatastore(datastoreConfig)
-
+    val datastore = new DynamoDatastore(config.dynamoConfig)
     val txService = new TransactorService(client, executor, datastore)
 
     TransactorService.createServerThread(txService,

--- a/transactor/src/main/scala/io/mediachain/transactor/RpcService.scala
+++ b/transactor/src/main/scala/io/mediachain/transactor/RpcService.scala
@@ -25,8 +25,16 @@ object RpcService {
     client.connect(cluster)
 
     implicit val ec = ExecutionContext.global
+    // todo: dynamic
+    val executor = Executors.newFixedThreadPool(4)
+    val datastoreConfig = DynamoDatastore.Config(
+      "Mediachain",
+      new BasicAWSCredentials("", ""),
+      Some("http://localhost:8000")
+    )
+    val datastore = new DynamoDatastore(datastoreConfig)
 
-    val txService = new TransactorService(client)
+    val txService = new TransactorService(client, executor, datastore)
 
     TransactorService.createServerThread(txService,
       Executors.newSingleThreadExecutor(),

--- a/translation_engine/src/main/scala/io/mediachain/translation/JsonLoader.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/JsonLoader.scala
@@ -12,8 +12,8 @@ object JsonLoader {
   import java.net.{URI, URL}
   import org.json4s._
   import org.json4s.jackson.JsonMethods._
-  import cats.data.{Streaming, Xor}
-  import cats.implicits._
+  import cats.data.Xor
+  import dogs.Streaming
   import com.fasterxml.jackson.core.{JsonParser, JsonToken}
 
   def createParser(s: String)(implicit factory: JsonFactory): Xor[TranslationError, JsonParser] = {
@@ -105,7 +105,7 @@ object JsonLoader {
         parseJValue(parser) match {
           case r@Xor.Right(_) =>
             parser.nextToken
-            r %:: helper
+            Streaming.cons(r, helper)
           case l => Streaming(l)
         }
       }


### PR DESCRIPTION
Adds a Vagrantfile and ansible config to install oracle java, sbt and dynamodb-local

Also adds an `io.mediachain.transactor.Main` object to act as a unified entry point for both the JournalServer and RpcService.  

check out this fancy usage text:

```
mediachain
Usage: mediachain [transactor|facade] [options]

  -l <host:port> | --listen <host:port>
        bind address
  -c <host1:port1>,<host2:port2> | --cluster-addresses <host1:port1>,<host2:port2>
        addresses of transactor cluster members
  -t <value> | --table-name <value>
        base name of dynamo-db table
  -s <value> | --ssl-properties <value>
        path to properties file for ssl configuration
  -e <value> | --dynamo-endpoint <value>
        endpoint for dynamo-db
Command: transactor [options]
run the transactor
  -d <value> | --data <value>
        directory to store transactor data
  -i | --interactive
        accept control commands from standard input
Command: facade
run an RPC facade to the transactor cluster
```

the ssl config still uses the property file, and the AWS access and secret keys are expected to come from the aws cli configuration.
