### PR TITLE
Additional provision script for transactor clients

### DIFF
--- a/provisioning/playbooks/transactor-client-provisioning.yml
+++ b/provisioning/playbooks/transactor-client-provisioning.yml
@@ -4,6 +4,12 @@
     - transactor
 
   tasks:
+  - name: install pip
+    apt: name=python-pip state=present
+
+  - name: update to latest pip
+    shell: pip install --upgrade pip
+    
   - name: checkout mediachain
     git: repo=https://github.com/mediachain/mediachain.git dest=/home/ubuntu/mediachain
 

--- a/provisioning/playbooks/transactor-client-provisioning.yml
+++ b/provisioning/playbooks/transactor-client-provisioning.yml
@@ -1,0 +1,20 @@
+---
+- hosts: transactor-client-provisioning
+  roles:
+    - transactor
+
+  tasks:
+  - name: checkout mediachain
+    git: repo=https://github.com/mediachain/mediachain.git dest=/home/ubuntu/mediachain
+
+  - name: set ownership of mediachain src tree
+    file: path=/home/ubuntu/mediachain owner=ubuntu group=ubuntu recurse=yes
+
+  - name: checkout mediachain-client
+    git: repo=https://github.com/mediachain/mediachain-client.git dest=/home/ubuntu/mediachain-client
+
+  - name: set ownership of mediachain-client src tree
+    file: path=/home/ubuntu/mediachain-client owner=ubuntu group=ubuntu recurse=yes
+
+  - name: prepare /mnt/data
+    file: path=/mnt/data state=directory owner=ubuntu group=ubuntu

--- a/provisioning/playbooks/transactor-client-provisioning.yml
+++ b/provisioning/playbooks/transactor-client-provisioning.yml
@@ -8,7 +8,7 @@
     apt: name=python-pip state=present
 
   - name: update to latest pip
-    shell: pip install --upgrade pip
+    pip: name=pip state=latest
     
   - name: checkout mediachain
     git: repo=https://github.com/mediachain/mediachain.git dest=/home/ubuntu/mediachain


### PR DESCRIPTION
Like transactor, but also pulls medichain-client and configures /mnt/data instead of /mnt/transactor.
