### PR TITLE
Transactor RPC streaming rework

### DIFF
--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -24,9 +24,9 @@ message UpdateChainResult {
 
 message JournalEvent {
     oneof event {
-        MultihashReference canonicalInserted = 2;
-        UpdateChainResult chainUpdated = 3;
-        MultihashReference journalBlockPublished = 4;
+        MultihashReference insertCanonicalEvent = 1;
+        UpdateChainResult updateChainEvent = 2;
+        MultihashReference journalBlockEvent = 3;
     }
 }
 

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -14,9 +14,7 @@ message UpdateRequest {
     bytes chainCellCbor = 1;
 }
 
-message JournalStreamRequest {
-    MultihashReference lastJournalBlock = 1;
-}
+message JournalStreamRequest {}
 
 message UpdateChainResult {
     MultihashReference canonical = 1;

--- a/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Datastore.scala
@@ -3,7 +3,7 @@ package io.mediachain.protocol
 object Datastore {
   import io.mediachain.multihash.MultiHash
   import io.mediachain.protocol.CborSerialization._
-  import io.mediachain.protocol.Transactor.{ArtefactChainReference, ChainReference, EntityChainReference}
+  import io.mediachain.protocol.Transactor._
   import io.mediachain.util.cbor.CborAST._
   import scala.util.Try
   import dogs.Streaming
@@ -379,20 +379,6 @@ object Datastore {
       val defaults = Map("index" -> CInt(index), "entries" -> cborEntries)
       val optionals = Map("chain" -> chain.map(_.toCbor))
       super.toCMapWithDefaults(defaults, optionals)
-    }
-
-    def toStream(datastore: Datastore): Streaming[JournalBlock] = {
-      val next: Eval[Streaming[JournalBlock]] = chain match {
-        case Some(ref) => Eval.always {
-          datastore.get(ref) match {
-            case Some(x: JournalBlock) => x.toStream(datastore)
-            case _ => Streaming.empty
-          }
-        }
-        case _ => Eval.now(Streaming.empty)
-      }
-
-      Streaming.cons[JournalBlock](this, next)
     }
   }
   

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -213,7 +213,7 @@ extends ClientStateListener with JournalListener {
       }
     }
     
-    def fetchBlocks(hd: Option[Reference]) = {
+    def fetchBlocks(chainHead: Option[Reference]) = {
       def loop(ref: Reference, blocks: List[JournalBlock])
       : List[JournalBlock]
       = {
@@ -227,7 +227,7 @@ extends ClientStateListener with JournalListener {
         }
       }
       
-      hd match {
+      chainHead match {
         case Some(ref) => loop(ref, Nil)
         case None => Nil
       }

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -297,7 +297,7 @@ extends ClientStateListener with JournalListener {
         logger.info(s"Observer ${observer} cancelled; scheduling removal")
         removeObserver(observer)
         
-      case e: Throwable =>
+      case e: Exception =>
         logger.error(s"Error dispatching event to ${observer}", e)
         Try(observer.onError(e))
         removeObserver(observer)

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -102,6 +102,7 @@ extends ClientStateListener with JournalListener {
   private def removeStreamObserver(observer: Observer) {
     logger.info(s"Removing stream observer ${observer}")
     observers -= observer
+    dispatching -= observer
   }
   
   private def journalCommitEvent(entry: JournalEntry) {

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -17,203 +17,15 @@ import io.mediachain.protocol.transactor.Transactor
 import io.mediachain.protocol.transactor.Transactor.JournalEvent.Event
 import io.mediachain.protocol.transactor.Transactor.JournalEvent.Event.JournalBlockPublished
 import org.slf4j.LoggerFactory
-
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration.{Duration, SECONDS}
-import scala.collection.mutable.{Queue => MQueue, Stack => MStack}
-
-class BackfillRunner(offset: Reference,
-                     head: Reference,
-                     observer: StreamObserver[JournalEvent],
-                     datastore: Datastore)
-  extends Runnable {
-  private val logger = LoggerFactory.getLogger(classOf[BackfillRunner])
-  private val backfillStack: MStack[JournalEvent] = MStack()
-  private val queue: MQueue[JournalEvent] = MQueue()
-  private var backfilled: AtomicBoolean = new AtomicBoolean(false)
-  @volatile private var queueEmptied = false
-
-  /** For the time being, this naively executes in a single thread.
-    * This should eventually become a batched read of a few chain blocks
-    * followed by re-enqueuing this worker in the executor with an
-    * updated offset.
-    */
-  override def run(): Unit = {
-    val chain = datastore.get(head).collect {
-      case x: JournalBlock => x.toStream(datastore)
-    }.getOrElse(Streaming.empty).map(_.chain)
-
-    logger.debug(s"backfiller started. stream: $chain")
-
-    /*
-    a note: i'd really prefer to do something like
-
-    stream.flatMap(_.map(Streaming.apply).getOrElse(Streaming.empty))
-
-    but i'm not sure if that breaks the original continuation i'd set
-    up. i'll investigate. @bigs
-     */
-    Streaming.cons(Some(head), chain)
-      .takeWhile(x => x.isDefined && !x.contains(offset))
-      .iterator
-      .flatten
-      .foreach(backfillBlock)
-
-    logger.debug("filled backfill stack")
-
-    backfillStack.foreach(e => {
-        logger.debug(s"sending backfilled event: $e")
-        observer.onNext(e)
-      }
-    )
-
-    logger.debug("backfill complete")
-
-    backfilled.set(true)
-    while (queue.nonEmpty) {
-      observer.onNext(queue.dequeue())
-    }
-    logger.debug("event queue empty")
-    queueEmptied = true
-  }
-
-  def backfillBlock(blockRef: Reference): Unit = {
-    import TransactorService.refToRPCMultihashRef
-    val event = JournalEvent(
-      JournalBlockPublished(refToRPCMultihashRef(blockRef))
-    )
-    backfillStack.push(event)
-
-    // TODO: handle failure to retrieve block
-    datastore.getAs[JournalBlock](blockRef).foreach { block =>
-      val events = block.entries.reverse.map(TransactorService.journalEntryToEvent)
-      events.foreach(backfillStack.push)
-    }
-  }
-
-  def onNext(event: JournalEvent): Unit = {
-    if (backfilled.get) {
-      while (!queueEmptied) {
-        Thread.`yield`()
-      }
-
-      observer.onNext(event)
-    } else {
-      queue.enqueue(event)
-    }
-  }
-}
-
-class TransactorListener(executor: ExecutorService,
-                         datastore: Datastore,
-                         client: Client)
-  extends ClientStateListener with JournalListener {
-
-  import collection.mutable.{Set => MSet, Map => MMap}
-  import TransactorService.refToRPCMultihashRef
-
-  type OnNextFn = JournalEvent => Unit
-  type ObserverMap = MMap[StreamObserver[JournalEvent], OnNextFn]
-
-  private val logger = LoggerFactory.getLogger(classOf[TransactorService])
-  private val observers: ObserverMap = MMap()
-
-  private def makeContinuation(offset: MultihashReference,
-                               streamObserver: StreamObserver[JournalEvent])
-  : OnNextFn = {
-    import scala.concurrent.ExecutionContext.Implicits.global
-
-    Await.result(client.currentBlock, Duration(30, SECONDS)) match {
-      case JournalBlock(_, Some(chain), _) =>
-        val backfiller =
-          new BackfillRunner(offset, chain, streamObserver, datastore)
-        executor.execute(backfiller)
-
-        backfiller.onNext
-      case _ =>
-        // for now, just subscribe them. we can decide on error handling
-        // logic later.
-        streamObserver.onNext
-    }
-
-  }
-
-  def addObserver(streamObserver: StreamObserver[JournalEvent],
-                  offset: Option[MultihashReference]): Unit = {
-    observers.synchronized {
-      val onNext: OnNextFn = offset match {
-        case Some(o) => makeContinuation(o, streamObserver)
-        case _ => streamObserver.onNext
-      }
-
-      observers += (streamObserver -> onNext)
-    }
-  }
-
-  override def onStateChange(state: ClientState): Unit = {
-    logger.info(s"copycat state changed to $state")
-    if (state == ClientState.Disconnected) {
-      observers.synchronized {
-        observers.foreach { case (observer, _) =>
-          observer.onError(
-            new StatusRuntimeException(
-              Status.UNAVAILABLE
-                .withDescription("disconnected from transactor cluster")
-            )
-          )
-        }
-        observers.clear()
-      }
-    }
-  }
-
-  override def onJournalCommit(entry: JournalEntry): Unit = {
-    val event = TransactorService.journalEntryToEvent(entry)
-    publishEvent(event)
-  }
-
-  override def onJournalBlock(ref: Reference): Unit = {
-    import JournalEvent.Event
-    val event = Event.JournalBlockPublished(
-      refToRPCMultihashRef(ref)
-    )
-
-    publishEvent(JournalEvent().withEvent(event))
-  }
-
-
-  private def publishEvent(event: JournalEvent): Unit = {
-    observers.synchronized {
-      val cancelledObservers: MSet[StreamObserver[JournalEvent]] = MSet()
-      observers.foreach { case (observer, onNext) =>
-        try {
-          onNext(event)
-        } catch {
-          case e: StatusRuntimeException if e.getStatus == Status.CANCELLED =>
-            // if the client killed the connection, remove the observer
-            cancelledObservers.add(observer)
-          case t: Throwable =>
-            throw t
-        }
-      }
-
-      observers --= cancelledObservers
-    }
-  }
-}
+import scala.concurrent.{ExecutionContext, Future}
 
 class TransactorService(client: Client,
                         executor: ExecutorService,
-                        datastore: Datastore,
-                        timeout: Duration = Duration(120, SECONDS))
+                        datastore: Datastore)
                        (implicit val executionContext: ExecutionContext)
   extends TransactorServiceGrpc.TransactorService {
   private val logger = LoggerFactory.getLogger(classOf[TransactorService])
-  private val listener = new TransactorListener(executor, datastore, client)
-
-  client.addStateListener(listener)
-  client.listen(listener)
-
+  
   override def lookupChain(request: Transactor.MultihashReference):
   Future[Transactor.MultihashReference] = {
     val ref = MultiHash.fromBase58(request.reference)
@@ -297,16 +109,7 @@ class TransactorService(client: Client,
 
   override def journalStream(request: JournalStreamRequest,
     responseObserver: StreamObserver[JournalEvent]): Unit = {
-
-    val offset = for {
-      rpcRef <- request.lastJournalBlock
-      multihash = MultiHash.fromBase58(rpcRef.reference).getOrElse(
-        throw new StatusRuntimeException(
-          Status.INVALID_ARGUMENT.withDescription("Multihash reference is invalid")
-        ))
-    } yield MultihashReference(multihash)
-
-    listener.addObserver(responseObserver, offset)
+    throw new RuntimeException("XXX Implement me")
   }
 
 

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -18,9 +18,7 @@ import io.mediachain.protocol.transactor.Transactor.JournalEvent.Event
 import org.slf4j.LoggerFactory
 import scala.concurrent.{ExecutionContext, Future}
 
-class TransactorService(client: Client,
-                        executor: ExecutorService,
-                        datastore: Datastore)
+class TransactorService(client: Client, datastore: Datastore)
                        (implicit val executionContext: ExecutionContext)
   extends TransactorServiceGrpc.TransactorService {
   private val logger = LoggerFactory.getLogger(classOf[TransactorService])
@@ -152,22 +150,16 @@ object TransactorService {
   }
 
 
-  def createServerThread(service: TransactorService,
-                         executor: ExecutorService,
-                         port: Int)
-                        (implicit executionContext: ExecutionContext)
-  : Unit = {
+  def createServer(service: TransactorService, port: Int)
+                  (implicit executionContext: ExecutionContext)
+  = {
     import scala.language.existentials
-
+    
     val builder = ServerBuilder.forPort(port)
     val server = builder.addService(
       TransactorServiceGrpc.bindService(service, executionContext)
     ).build
-
-    executor.submit(new Runnable {
-      def run {
-        server.start
-      }})
+    server
   }
 }
 


### PR DESCRIPTION
Implements the transactor streaming service in the logical concurrent way:
- The backfilling behavior has been removed.
- Streaming begins at current block boundaries and absorbs transient copycat errors.
- Cleans up the threading situation
