### PR TITLE
Ansible GRPC playbook + other ansible tweaks

### DIFF
--- a/provisioning/Vagrantfile
+++ b/provisioning/Vagrantfile
@@ -13,14 +13,11 @@ Vagrant.configure(2) do |config|
   # share the parent directory at /mediachain
   config.vm.synced_folder "../", "/mediachain"
 
-  # Forward transactor rpc service port 10001
-  config.vm.network "forwarded_port", guest: 10001, host: 10001
-  
-  # Forward port for local dynamodb (for development)
-  config.vm.network "forwarded_port", guest: 8000, host: 8000
-
-  # Forward jvm debugger port 5005 on the guest to 5006 on the host
-  config.vm.network "forwarded_port", guest: 5005, host: 5006
+  if ENV["MC_VAGRANT_IP"]
+    config.vm.network "private_network", ip: ENV["MC_VAGRANT_IP"]
+  else
+    config.vm.network "private_network", type: "dhcp" 
+  end
 
   # Set ram, etc for vm providers
   config.vm.provider "virtualbox" do |vb|

--- a/provisioning/playbooks/dev.yml
+++ b/provisioning/playbooks/dev.yml
@@ -3,3 +3,4 @@
   roles:
     - { role: transactor }
     - { role: dynamodb_local, become: yes, become_user: "root" }
+    - { role: grpc }

--- a/provisioning/playbooks/dev.yml
+++ b/provisioning/playbooks/dev.yml
@@ -3,4 +3,4 @@
   roles:
     - { role: transactor }
     - { role: dynamodb_local, become: yes, become_user: "root" }
-    - { role: grpc }
+    - { role: grpc, grpc_checkout: "be223358795b645416e801727f4d3fcad3d73964" }

--- a/provisioning/playbooks/roles/apt_upgrade/tasks/main.yml
+++ b/provisioning/playbooks/roles/apt_upgrade/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: update system
+  apt: upgrade=yes
+  become: yes
+  become_user: "root"

--- a/provisioning/playbooks/roles/dynamodb_local/tasks/main.yml
+++ b/provisioning/playbooks/roles/dynamodb_local/tasks/main.yml
@@ -7,7 +7,7 @@
   get_url:
     url="http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_{{dynamodb_version}}.tar.gz"
     sha256sum="{{dynamodb_sha}}"
-    dest=/opt/dynamodb/
+    dest=/opt/dynamodb/dynamodb_local_{{dynamodb_version}}.tar.gz
   notify:
    - Restart DynamoDB
   register: dynamodb_download

--- a/provisioning/playbooks/roles/dynamodb_local/templates/dynamodb.init.sh.j2
+++ b/provisioning/playbooks/roles/dynamodb_local/templates/dynamodb.init.sh.j2
@@ -15,7 +15,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 NAME="dynamodb"
 DAEMON="$(which java)"
-ARGS="-Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar --port {{ dynamodb_port }}"
+ARGS="-Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar --port {{ dynamodb_port }} -sharedDb"
 JAR_NAME="DynamoDBLocal.jar"
 
 LOGFILE="/opt/dynamodb/dynamodb.log"

--- a/provisioning/playbooks/roles/grpc/defaults/main.yml
+++ b/provisioning/playbooks/roles/grpc/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+grpc_source_dir: /opt/grpc
+grpc_version: release-0_14_0
+grpc_version_number: "0.14.0"

--- a/provisioning/playbooks/roles/grpc/defaults/main.yml
+++ b/provisioning/playbooks/roles/grpc/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
+grpc_repo: https://github.com/grpc/grpc.git
 grpc_source_dir: /opt/grpc
-grpc_version: release-0_14_0
-grpc_version_number: "0.14.0"
+grpc_checkout: release-0_14_0

--- a/provisioning/playbooks/roles/grpc/meta/main.yml
+++ b/provisioning/playbooks/roles/grpc/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: python

--- a/provisioning/playbooks/roles/grpc/tasks/main.yml
+++ b/provisioning/playbooks/roles/grpc/tasks/main.yml
@@ -1,0 +1,40 @@
+
+- name: install grpc base dependencies
+  apt: name={{item}}
+  become: yes
+  become_user: root
+  with_items:
+      - python-dev
+      - python-pip
+      - libtool
+      - autoconf
+
+- name: clone grpc git repo
+  git: repo=https://github.com/grpc/grpc.git
+       dest={{ grpc_source_dir }}
+       version={{ grpc_version }}
+  become: yes
+  become_user: root
+
+- name: install gprc python dependencies
+  command: pip install -r requirements.txt
+  args:
+    chdir: "{{ grpc_source_dir }}"
+  become: yes
+  become_user: root
+
+- name: install grpc python module
+  command: env GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
+  args:
+    chdir: "{{ grpc_source_dir }}"
+    creates: "/usr/local/lib/python2.7/dist-packages/grpcio-{{ grpc_version_number }}.egg-info"
+  become: yes
+  become_user: root
+
+- name: build and install grpc
+  shell: make install && rm -f ./.grpc_version_installed_* && touch ".grpc_version_installed_{{grpc_version}}"
+  args:
+    chdir: "{{ grpc_source_dir }}"
+    creates: "{{grpc_source_dir}}/.grpc_version_installed_{{grpc_version}}"
+  become: yes
+  become_user: root

--- a/provisioning/playbooks/roles/grpc/tasks/main.yml
+++ b/provisioning/playbooks/roles/grpc/tasks/main.yml
@@ -9,32 +9,40 @@
       - libtool
       - autoconf
 
-- name: clone grpc git repo
-  git: repo=https://github.com/grpc/grpc.git
-       dest={{ grpc_source_dir }}
-       version={{ grpc_version }}
+- name: update pip
+  pip: name=pip state=latest
   become: yes
   become_user: root
 
-- name: install gprc python dependencies
-  command: pip install -r requirements.txt
-  args:
-    chdir: "{{ grpc_source_dir }}"
+- name: clone grpc git repo
+  git: repo={{ grpc_repo }}
+       dest={{ grpc_source_dir }}
+       version={{ grpc_checkout }}
   become: yes
   become_user: root
 
 - name: install grpc python module
-  command: env GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
+  shell: >
+    make clean && \
+    pip install -r requirements.txt && \
+    env GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install . && \
+    rm -f {{ grpc_source_dir }}/.grpc_python_version_installed_* && \
+    touch "{{ grpc_source_dir }}/.grpc_python_version_installed_{{ grpc_checkout }}"
   args:
     chdir: "{{ grpc_source_dir }}"
-    creates: "/usr/local/lib/python2.7/dist-packages/grpcio-{{ grpc_version_number }}.egg-info"
+    creates: "{{grpc_source_dir}}/.grpc_python_version_installed_{{ grpc_checkout }}"
   become: yes
   become_user: root
 
 - name: build and install grpc
-  shell: make install && rm -f ./.grpc_version_installed_* && touch ".grpc_version_installed_{{grpc_version}}"
+  shell: > 
+    make clean && \
+    make install && \
+    (cd third_party/protobuf && make install && make clean) && \
+    rm -f {{ grpc_source_dir }}/.grpc_version_installed_* && \
+    touch "{{ grpc_source_dir }}/.grpc_version_installed_{{grpc_checkout}}"
   args:
     chdir: "{{ grpc_source_dir }}"
-    creates: "{{grpc_source_dir}}/.grpc_version_installed_{{grpc_version}}"
+    creates: "{{ grpc_source_dir }}/.grpc_version_installed_{{grpc_checkout}}"
   become: yes
   become_user: root

--- a/provisioning/playbooks/roles/grpc/tasks/main.yml
+++ b/provisioning/playbooks/roles/grpc/tasks/main.yml
@@ -1,48 +1,36 @@
+- block:
+  - name: install grpc base dependencies
+    apt: name={{item}}
+    with_items:
+        - libtool
+        - autoconf
 
-- name: install grpc base dependencies
-  apt: name={{item}}
-  become: yes
-  become_user: root
-  with_items:
-      - python-dev
-      - python-pip
-      - libtool
-      - autoconf
+  - name: clone grpc git repo
+    git: repo={{ grpc_repo }}
+         dest={{ grpc_source_dir }}
+         version={{ grpc_checkout }}
 
-- name: update pip
-  pip: name=pip state=latest
-  become: yes
-  become_user: root
+  - name: install grpc python module
+    shell: >
+      make clean && \
+      pip install -r requirements.txt && \
+      env GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install . && \
+      rm -f {{ grpc_source_dir }}/.grpc_python_version_installed_* && \
+      touch "{{ grpc_source_dir }}/.grpc_python_version_installed_{{ grpc_checkout }}"
+    args:
+      chdir: "{{ grpc_source_dir }}"
+      creates: "{{grpc_source_dir}}/.grpc_python_version_installed_{{ grpc_checkout }}"
 
-- name: clone grpc git repo
-  git: repo={{ grpc_repo }}
-       dest={{ grpc_source_dir }}
-       version={{ grpc_checkout }}
-  become: yes
-  become_user: root
+  - name: build and install grpc
+    shell: > 
+      make clean && \
+      make install && \
+      (cd third_party/protobuf && make install && make clean) && \
+      rm -f {{ grpc_source_dir }}/.grpc_version_installed_* && \
+      touch "{{ grpc_source_dir }}/.grpc_version_installed_{{grpc_checkout}}"
+    args:
+      chdir: "{{ grpc_source_dir }}"
+      creates: "{{ grpc_source_dir }}/.grpc_version_installed_{{grpc_checkout}}"
 
-- name: install grpc python module
-  shell: >
-    make clean && \
-    pip install -r requirements.txt && \
-    env GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install . && \
-    rm -f {{ grpc_source_dir }}/.grpc_python_version_installed_* && \
-    touch "{{ grpc_source_dir }}/.grpc_python_version_installed_{{ grpc_checkout }}"
-  args:
-    chdir: "{{ grpc_source_dir }}"
-    creates: "{{grpc_source_dir}}/.grpc_python_version_installed_{{ grpc_checkout }}"
-  become: yes
-  become_user: root
-
-- name: build and install grpc
-  shell: > 
-    make clean && \
-    make install && \
-    (cd third_party/protobuf && make install && make clean) && \
-    rm -f {{ grpc_source_dir }}/.grpc_version_installed_* && \
-    touch "{{ grpc_source_dir }}/.grpc_version_installed_{{grpc_checkout}}"
-  args:
-    chdir: "{{ grpc_source_dir }}"
-    creates: "{{ grpc_source_dir }}/.grpc_version_installed_{{grpc_checkout}}"
   become: yes
   become_user: root

--- a/provisioning/playbooks/roles/python/tasks/main.yml
+++ b/provisioning/playbooks/roles/python/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- block:
+    - name: install pip
+      apt: name=python-pip state=present
+
+    - name: install python-dev
+      apt: name=python-dev state=present
+
+    - name: install virtualenv
+      apt: name=python-virtualenv state=present
+
+    - name: update pip to latest version
+      pip: name=pip state=latest
+  
+  become: yes
+  become_user: "root"

--- a/provisioning/playbooks/roles/transactor/tasks/main.yml
+++ b/provisioning/playbooks/roles/transactor/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: update system
-  apt: upgrade=yes
-  become: yes
-  become_user: "root"
 
 - name: setup git ppa repo
   apt_repository: repo=ppa:git-core/ppa

--- a/provisioning/playbooks/transactor-client-provisioning.yml
+++ b/provisioning/playbooks/transactor-client-provisioning.yml
@@ -7,6 +7,12 @@
   - name: install pip
     apt: name=python-pip state=present
 
+  - name: install libjpeg-dev
+    apt: name=libjpeg-dev state=present
+
+  - name: install libpng-dev
+    apt: name=libpng-dev state=present
+
   - name: update to latest pip
     pip: name=pip state=latest
     

--- a/provisioning/playbooks/transactor-client-provisioning.yml
+++ b/provisioning/playbooks/transactor-client-provisioning.yml
@@ -2,6 +2,7 @@
 - hosts: transactor-client-provisioning
   roles:
     - transactor
+    - {role: grpc, grpc_checkout: "be223358795b645416e801727f4d3fcad3d73964" }
 
   tasks:
   - name: install pip

--- a/provisioning/playbooks/transactor-client-provisioning.yml
+++ b/provisioning/playbooks/transactor-client-provisioning.yml
@@ -1,12 +1,12 @@
 ---
 - hosts: transactor-client-provisioning
   roles:
+    - apt_upgrade
     - transactor
+    - python
     - {role: grpc, grpc_checkout: "be223358795b645416e801727f4d3fcad3d73964" }
 
   tasks:
-  - name: install pip
-    apt: name=python-pip state=present
 
   - name: install libjpeg-dev
     apt: name=libjpeg-dev state=present
@@ -14,9 +14,6 @@
   - name: install libpng-dev
     apt: name=libpng-dev state=present
 
-  - name: update to latest pip
-    pip: name=pip state=latest
-    
   - name: checkout mediachain
     git: repo=https://github.com/mediachain/mediachain.git dest=/home/ubuntu/mediachain
 

--- a/provisioning/playbooks/transactor-provisioning.yml
+++ b/provisioning/playbooks/transactor-provisioning.yml
@@ -4,6 +4,11 @@
     - transactor
 
   tasks:
+  - name: update system
+    apt: upgrade=yes
+    become: yes
+    become_user: "root"
+
   - name: checkout mediachain
     git: repo=https://github.com/mediachain/mediachain.git dest=/home/ubuntu/mediachain
 

--- a/provisioning/playbooks/transactor-provisioning.yml
+++ b/provisioning/playbooks/transactor-provisioning.yml
@@ -1,14 +1,10 @@
 ---
 - hosts: transactor-provisioning
   roles:
+    - apt_upgrade
     - transactor
 
   tasks:
-  - name: update system
-    apt: upgrade=yes
-    become: yes
-    become_user: "root"
-
   - name: checkout mediachain
     git: repo=https://github.com/mediachain/mediachain.git dest=/home/ubuntu/mediachain
 


### PR DESCRIPTION
This adds a grpc playbook to checkout and build grpc from source.  

You can override the default repo by setting the `grpc_repo` variable, and the tag / commit to checkout with `grpc_checkout`.  Technically you could put a branch name for `grpc_checkout`, but that will mess with the idempotency check.  When the playbook installs grpc it drops a file at `/opt/grpc/.grpc_version_installed{{ grpc_checkout }}` to avoid rebuilding after it's already installed.  So if you use a branch name, it won't trigger a rebuild if the branch tip changes.

Also does a few other things:
- adds the `-sharedDb` flag to the local dynamo db service, and fixes the idempotency check on downloading the dynamo jar
- moves the `apt upgrade` task from the transactor playbook to `transactor-provisioning.yml` b/c it was messing up my vmware box when the kernel got updated
- adds some missing dependencies to `transactor-client-provisioning.yml` (libjpeg-dev and libpng-dev)
- adds the new grpc role to `dev.yml` and `transactor-client-provisioning.yml`, pinned to the latest commit on master -- [be223358795b645416e801727f4d3fcad3d73964](https://github.com/grpc/grpc/commit/be223358795b645416e801727f4d3fcad3d73964)

It would be nice if the grpc role could optionally install to a virtualenv, but I didn't want to get carried away :)

Also, the grpc playbook does pretty much everything as root, since it's set to checkout the code to `/opt/grpc` by default and needs write permissions.  I'd like to just check it out to the home dir instead, but the username varies between vagrant and the deployment env, and I don't know how to abstract that in ansible.  I guess I could add a `current_user` variable to the playbook, but it seems like that's probably built in to ansible and I just haven't found it.
