### PR TITLE
Modify the Transactor lookup API to distinguish nil chains from bad references

### DIFF
--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -16,6 +16,15 @@ message UpdateRequest {
 
 message JournalStreamRequest {}
 
+message Nil {}
+
+message ChainReference {
+    oneof reference {
+        MultihashReference chain = 1;
+        Nil nil = 2;
+    }
+}
+
 message UpdateChainResult {
     MultihashReference canonical = 1;
     MultihashReference chain = 2;
@@ -38,7 +47,7 @@ service TransactorService {
         (MultihashReference);
 
     rpc LookupChain(MultihashReference) returns
-        (MultihashReference);
+        (ChainReference);
 
     rpc JournalStream(JournalStreamRequest) returns
         (stream JournalEvent);

--- a/protocol/src/main/protobuf/Transactor.proto
+++ b/protocol/src/main/protobuf/Transactor.proto
@@ -16,12 +16,12 @@ message UpdateRequest {
 
 message JournalStreamRequest {}
 
-message Nil {}
+message NullReference {}
 
 message ChainReference {
     oneof reference {
         MultihashReference chain = 1;
-        Nil nil = 2;
+        NullReference nil = 2;
     }
 }
 

--- a/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
@@ -31,7 +31,7 @@ object Transactor {
   trait Journal {
     def insert(rec: CanonicalRecord): Future[Xor[JournalError, CanonicalEntry]]
     def update(ref: Reference, cell: ChainCell): Future[Xor[JournalError, ChainEntry]]
-    def lookup(ref: Reference): Future[Option[Reference]]
+    def lookup(ref: Reference): Future[Xor[JournalError, Option[Reference]]]
     def currentBlock: Future[JournalBlock]
   }
 
@@ -55,5 +55,9 @@ object Transactor {
   
   case class JournalDuplicateError(ref: Reference) extends JournalError {
     override def toString = "Duplicate Journal Insert: " + ref
+  }
+  
+  case class JournalReferenceError(ref: Reference) extends JournalError {
+    override def toString = "Bad reference: " + ref
   }
 }

--- a/transactor/src/main/scala/io/mediachain/copycat/Client.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Client.scala
@@ -190,7 +190,7 @@ class Client(client: CopycatClient) extends JournalClient {
   def update(ref: Reference, cell: ChainCell): Future[Xor[JournalError, ChainEntry]] =
     submit(JournalUpdate(ref, cell))
   
-  def lookup(ref: Reference): Future[Option[Reference]] = 
+  def lookup(ref: Reference): Future[Xor[JournalError, Option[Reference]]] = 
     submit(JournalLookup(ref))
   
   def currentBlock: Future[JournalBlock] =

--- a/transactor/src/test/scala/io/mediachain/copycat/JournalClusterSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/JournalClusterSpec.scala
@@ -71,7 +71,7 @@ object JournalClusterSpec extends io.mediachain.BaseSpec
         }
     }
     val expected = context.refs.map {
-      case (_, chainRef) => context.cluster.dummies.map {_ => Some(chainRef)}
+      case (_, chainRef) => context.cluster.dummies.map {_ => Xor.Right(Some(chainRef))}
     }
     views must_== expected
   }

--- a/transactor/src/test/scala/io/mediachain/copycat/JournalIndexSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/JournalIndexSpec.scala
@@ -53,7 +53,9 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val ref = context.entityRef
     val op = context.dummy.client.lookup(ref)
     val res = Await.result(op, timeout)
-    res must beNone
+    res must beRightXor { (ref: Option[Reference]) =>
+      ref must beNone
+    }
   }
   
   def extendEntityChain = {
@@ -74,8 +76,10 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val chainRef = context.entityChainRef
     val op = context.dummy.client.lookup(ref)
     val res = Await.result(op, timeout)
-    (res must beSome) and 
-    (res.get must_== chainRef)
+    res must beRightXor { (ref: Option[Reference]) =>
+      (ref must beSome) and 
+      (ref.get must_== chainRef)
+    }
   }
   
   def extendEntityChainFurther = {
@@ -105,7 +109,9 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val ref = context.artefactRef
     val op = context.dummy.client.lookup(ref)
     val res = Await.result(op, timeout)
-    res must beNone
+    res must beRightXor { (ref: Option[Reference]) =>
+      ref must beNone
+    }
   }
   
   def extendArtefactChain = {
@@ -126,8 +132,10 @@ object JournalIndexSpec extends io.mediachain.BaseSpec
     val chainRef = context.artefactChainRef
     val op = context.dummy.client.lookup(ref)
     val res = Await.result(op, timeout)
-    (res must beSome) and 
-    (res.get must_== chainRef)
+    res must beRightXor { (ref: Option[Reference]) =>
+      (ref must beSome) and 
+      (ref.get must_== chainRef)
+    }
   }
 
   def extendArtefactChainFurther = {


### PR DESCRIPTION
The lookup API currently does not allow a client to distinguish a nil chain from a canonical reference unknown to the journal.
This PR modifies the lookup API to distinguish the two cases by returning an Xor and mapping the option to the protobuf interface.
