### PR TITLE
transactor: Show log timestamps by default

### DIFF
--- a/transactor/src/main/resources/simplelogger.properties
+++ b/transactor/src/main/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+org.slf4j.simpleLogger.showDateTime: true
+org.slf4j.simpleLogger.dateTimeFormat: [dd/MM/yyyy:HH:mm:ss Z]


### PR DESCRIPTION
Adds the magic resource file for the slf4j logger we are using.
