### PR TITLE
TransactorService Streaming: Fix a race condition with better state synchronization

### DIFF
--- a/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
+++ b/protocol/src/main/scala/io/mediachain/protocol/Transactor.scala
@@ -44,7 +44,7 @@ object Transactor {
 
   trait JournalListener {
     def onJournalCommit(entry: JournalEntry): Unit
-    def onJournalBlock(ref: Reference): Unit
+    def onJournalBlock(ref: Reference, index: BigInt): Unit
   }
 
   sealed abstract class JournalError extends Serializable

--- a/transactor/src/main/scala/io/mediachain/copycat/Client.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Client.scala
@@ -227,7 +227,7 @@ class Client(client: CopycatClient) extends JournalClient {
       client.onEvent("journal-block", 
                      new Consumer[JournalBlockEvent] { 
         def accept(evt: JournalBlockEvent) { 
-          listeners.foreach(_.onJournalBlock(evt.ref))
+          listeners.foreach(_.onJournalBlock(evt.ref, evt.index))
         }
       })
     } else {

--- a/transactor/src/main/scala/io/mediachain/copycat/S3BackingStore.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/S3BackingStore.scala
@@ -65,8 +65,8 @@ extends JournalListener with ClientStateListener with AutoCloseable {
   // JournalListener
   def onJournalCommit(entry: JournalEntry) {}
 
-  def onJournalBlock(ref: Reference) {
-    logger.info(s"New block ${ref}")
+  def onJournalBlock(ref: Reference, index: BigInt) {
+    logger.info(s"New block ${ref} (${index})")
     execWriteBlock(ref)
   }
   

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -131,7 +131,7 @@ extends ClientStateListener with JournalListener {
   private def journalCommitEvent(entry: JournalEntry) {
     if (state.streaming) {
       state.block += entry
-      state.index = entry.index
+      state.index = entry.index + 1
       emitEvent(TransactorService.journalEntryToEvent(entry)) 
     }
   }

--- a/transactor/src/test/scala/io/mediachain/copycat/JournalBlockchainSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/JournalBlockchainSpec.scala
@@ -125,7 +125,7 @@ object JournalBlockchainSpecContext {
     val dummy = DummyContext.setup("127.0.0.1:10002", BlockSize)
     val queue = new LinkedBlockingQueue[Reference]
     dummy.client.listen(new JournalListener {
-      def onJournalBlock(ref: Reference) {
+      def onJournalBlock(ref: Reference, index: BigInt) {
           queue.offer(ref)
       }
       def onJournalCommit(entry: JournalEntry) {}

--- a/transactor/src/test/scala/io/mediachain/copycat/JournalBlockchainSpec2.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/JournalBlockchainSpec2.scala
@@ -57,7 +57,7 @@ object JournalBlockchainSpec2Context {
     val dummy = DummyContext.setup("127.0.0.1:10003")
     val queue = new LinkedBlockingQueue[Reference]
     dummy.client.listen(new JournalListener {
-      def onJournalBlock(ref: Reference) {
+      def onJournalBlock(ref: Reference, index: BigInt) {
           queue.offer(ref)
       }
       def onJournalCommit(entry: JournalEntry) {}

--- a/transactor/src/test/scala/io/mediachain/copycat/JournalClusterSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/JournalClusterSpec.scala
@@ -149,7 +149,7 @@ object JournalClusterSpecContext {
         def onJournalCommit(entry: JournalEntry) {
           commits.offer(entry)
         }
-        def onJournalBlock(ref: Reference) {
+        def onJournalBlock(ref: Reference, index: BigInt) {
           blocks.offer(ref)
         }
       })

--- a/transactor/src/test/scala/io/mediachain/copycat/JournalCommitSpec.scala
+++ b/transactor/src/test/scala/io/mediachain/copycat/JournalCommitSpec.scala
@@ -106,7 +106,7 @@ object JournalCommitSpecContext {
       def onJournalCommit(entry: JournalEntry) {
         queue.offer(entry)
       }
-      def onJournalBlock(ref: Reference) {}
+      def onJournalBlock(ref: Reference, index: BigInt) {}
     })
     instance = new JournalCommitSpecContext(dummy, qclient, queue)
   }


### PR DESCRIPTION
While reviewing the code I noticed that there is a window between currentBlock and its completion which could lead to some JournalEvents to be duplicated and corrupt state, even though they were superseded by the current block.

This patch fixes the race condition by tracking the next entry index and ignoring blocks events with smaller indices.
It turns out that this requires tracking the index in JournalBlockEvents, as emitted by the copycat StateMachine.
The change is internal to the transactor components and not propagated in the TransactorService interface.
