### PR TITLE
wip - publish to sonatype

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -43,7 +43,7 @@ object MediachainBuild extends Build {
   lazy val transactor = Project("transactor", file("transactor"))
     .settings(settings ++ Seq(
       libraryDependencies ++= Seq(
-        "io.mediachain" %% "multihash" % "0.1-SNAPSHOT",
+        "io.mediachain" %% "multihash" % "0.1.0",
         "io.atomix.copycat" % "copycat-server" % "1.1.4",
         "io.atomix.copycat" % "copycat-client" % "1.1.4",
         "io.atomix.catalyst" % "catalyst-netty" % "1.1.1",
@@ -80,7 +80,7 @@ object MediachainBuild extends Build {
         version in PB.protobufConfig := "3.0.0-beta-2",
 
         libraryDependencies ++= Seq(
-          "io.mediachain" %% "multihash" % "0.1-SNAPSHOT",
+          "io.mediachain" %% "multihash" % "0.1.0",
           "io.grpc" % "grpc-all" % "0.14.0",
           "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" %
             (PB.scalapbVersion in PB.protobufConfig).value

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -111,6 +111,7 @@ object MediachainBuild extends Build {
           val oldStrategy = (assemblyMergeStrategy in assembly).value
           oldStrategy(x)
       },
+      assemblyJarName in assembly := "transactor-assembly.jar",
       mainClass := Some("io.mediachain.transactor.Main")
     ))
     .dependsOn(protocol)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,9 @@ object MediachainBuild extends Build {
     scalaVersion := "2.11.7",
     scalacOptions ++= Seq("-Xlint", "-deprecation", "-Xfatal-warnings",
       "-feature", "-language:higherKinds"),
-    // resolvers += Resolver.mavenLocal, // local maven for tip debugging
+    resolvers ++= Seq(
+      Resolver.sonatypeRepo("public")
+    ),
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats" % "0.4.1",
       "org.typelevel" %% "dogs-core" % "0.2.2",
@@ -37,15 +39,11 @@ object MediachainBuild extends Build {
   lazy val utils = Project("utils", file("utils"))
     .settings(settings)
 
-  // TODO: replace this with maven-published version
-  val scalaMultihashCommit = "b2999d6c00b3acab6ea3ff5d0965634bed3a3823"
-  lazy val scalaMultihash = RootProject(uri(
-    s"git://github.com/mediachain/scala-multihash.git#$scalaMultihashCommit"
-  ))
 
   lazy val transactor = Project("transactor", file("transactor"))
     .settings(settings ++ Seq(
       libraryDependencies ++= Seq(
+        "io.mediachain" %% "multihash" % "0.1-SNAPSHOT",
         "io.atomix.copycat" % "copycat-server" % "1.1.4",
         "io.atomix.copycat" % "copycat-client" % "1.1.4",
         "io.atomix.catalyst" % "catalyst-netty" % "1.1.1",
@@ -66,11 +64,6 @@ object MediachainBuild extends Build {
       mainClass := Some("io.mediachain.transactor.Main")
     ))
     .dependsOn(protocol)
-    .dependsOn(scalaMultihash)
-
-  Resolver.sonatypeRepo("public")
-
-  updateOptions := updateOptions.value.withCachedResolution(true)
 
   lazy val protocol = Project("protocol", file("protocol"))
     .settings(settings ++ Seq(
@@ -87,13 +80,13 @@ object MediachainBuild extends Build {
         version in PB.protobufConfig := "3.0.0-beta-2",
 
         libraryDependencies ++= Seq(
+          "io.mediachain" %% "multihash" % "0.1-SNAPSHOT",
           "io.grpc" % "grpc-all" % "0.14.0",
           "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" %
             (PB.scalapbVersion in PB.protobufConfig).value
         )
       )
     )
-    .dependsOn(scalaMultihash)
 
   // aggregate means commands will cascade to the subprojects
   // dependsOn means classes will be available

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,8 +1,10 @@
 import sbt._
 import Keys._
 import sbtassembly.AssemblyKeys._
-import sbtassembly.{MergeStrategy,PathList}
+import sbtassembly.{MergeStrategy, PathList}
 import com.trueaccord.scalapb.{ScalaPbPlugin => PB}
+import sbtbuildinfo.BuildInfoPlugin, BuildInfoPlugin._
+import sbtbuildinfo.BuildInfoKeys._
 
 object MediachainBuild extends Build {
   updateOptions := updateOptions.value.withCachedResolution(true)
@@ -131,7 +133,10 @@ object MediachainBuild extends Build {
   // dependsOn means classes will be available
   lazy val mediachain = (project in file("."))
     .aggregate(transactor, protocol)
+    .enablePlugins(BuildInfoPlugin)
     .settings(Seq(
+      buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+      buildInfoPackage := "io.mediachain.build",
       // Don't publish an artifact for the root project
       publishArtifact := false,
       // sbt-pgp will choke if there's no repo, even tho it's unsed

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ libraryDependencies ++= Seq(
 )
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,5 @@ addSbtPlugin("com.trueaccord.scalapb" % "sbt-scalapb" % "0.5.21")
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.0.0-b2"
 )
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")

--- a/provisioning/playbooks/roles/transactor_server/files/transactor-svc
+++ b/provisioning/playbooks/roles/transactor_server/files/transactor-svc
@@ -104,7 +104,6 @@ if [ $# -lt 2 ]; then
     usage_error
 fi
 
-version=0.0.1
 mediachain_home=${MEDIACHAIN_HOME:-$HOME/mediachain}
 transactor_home=${TRANSACTOR_HOME:-$HOME/transactor}
 transactor_data=${TRANSACTOR_DATADIR:-/mnt/transactor}
@@ -117,7 +116,7 @@ awscreds=${transactor_home}/awscreds.sh
 pidfile=${transactor_data}/${service}.pid
 logfile=${transactor_data}/${service}.log
 ctlfile=${transactor_data}/ctl/${service}/shutdown
-bigjar=${mediachain_home}/transactor/target/scala-2.11/transactor-assembly-${version}.jar 
+bigjar=${mediachain_home}/transactor/target/scala-2.11/transactor-assembly.jar
 
 case $action in
     start)


### PR DESCRIPTION
So far, just resolves the scala-multihash dependency from sonatype instead of using a git project dependency.  I figured that'd be a better project for "learning the ropes" for this crazy publication workflow.

Next up:
- [x] Add publication metadata to base settings
- [x] Publish protocol and transactor projects to sonatype
- [ ] figure out how to automate deployment in travis CI
