### PR TITLE
Add object metrics to transactor service

### DIFF
--- a/transactor/src/main/scala/io/mediachain/util/Metrics.scala
+++ b/transactor/src/main/scala/io/mediachain/util/Metrics.scala
@@ -14,6 +14,14 @@ class Metrics(influx: InfluxDB, db: String) {
       .build()
     influx.write(db, "default", pt)
   }
+  
+  def gauge(measure: String, tags: Map[String, String], value: Long) {
+    val pt = Point.measurement(measure)
+      .tag(tags)
+      .addField("value", value)
+      .build()
+    influx.write(db, "default", pt)
+  }
 }
 
 object Metrics {


### PR DESCRIPTION
A counter tracks record insert/update and a gauge tracking the current index (height of the blockchain).
