### PR TITLE
Another battle with copybugs

### DIFF
--- a/provisioning/playbooks/roles/transactor_server/files/transactor-svc
+++ b/provisioning/playbooks/roles/transactor_server/files/transactor-svc
@@ -133,5 +133,5 @@ case $action in
         svc_restart
         ;;
     *)
-        usage
+        usage_error
 esac

--- a/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
@@ -128,6 +128,19 @@ object Serializers {
       state
     }
     
+    // direct access implementation
+    def write(buf: BufferOutput[_ <: BufferOutput[_]], state: JournalState) {
+      writeBlock(buf, state)
+      writeIndex(buf, state)
+    }
+
+    def read(buf: BufferInput[_ <: BufferInput[_]]): JournalState = {
+      val state = new JournalState
+      readBlock(buf, state)
+      readIndex(buf, state)
+      state
+    }
+    
     // implementation
     private def writeBlock(buf: BufferOutput[_ <: BufferOutput[_]], state: JournalState) {
       buf.writeLong(state.seqno.toLong) // it will be a cold day in hell if this overflows

--- a/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Serializers.scala
@@ -21,7 +21,6 @@ object Serializers {
     serializer.register(classOf[JournalInsert], classOf[JournalInsertSerializer])
     serializer.register(classOf[JournalUpdate], classOf[JournalUpdateSerializer])
     serializer.register(classOf[JournalLookup], classOf[JournalLookupSerializer])
-    serializer.register(classOf[JournalState], classOf[JournalStateSerializer])
   }
   
   def readBytes(buf: BufferInput[_ <: BufferInput[_]]): Array[Byte] = {
@@ -113,6 +112,9 @@ object Serializers {
   
   // JournalState serialization: serialization is required to be as fast as possible
   // because it dominates snapshot times, so we pardon all crimes and go straight to bytes
+  // unfortunately it falls short and ends up being slower than POJO serialization.
+  // only obvious way to make it faster is to avoid the copying from MultiHash.bytes
+  // (requires change in scala-multihash)
   class JournalStateSerializer extends TypeSerializer[JournalState] {
 
     def write(state: JournalState, buf: BufferOutput[_ <: BufferOutput[_]], ser: Serializer) {

--- a/transactor/src/main/scala/io/mediachain/copycat/Server.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Server.scala
@@ -30,9 +30,9 @@ object Server {
         .withStorageLevel(StorageLevel.DISK)
         .build())
       .withTransport(Transport.build(4, sslConfig))
-      .withElectionTimeout(Duration.ofSeconds(3))
+      .withElectionTimeout(Duration.ofSeconds(10))
       .withHeartbeatInterval(Duration.ofSeconds(1))
-      .withSessionTimeout(Duration.ofSeconds(5))
+      .withSessionTimeout(Duration.ofSeconds(10))
       .build()
     Serializers.register(server.serializer)
     server

--- a/transactor/src/main/scala/io/mediachain/copycat/Server.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Server.scala
@@ -30,9 +30,9 @@ object Server {
         .withStorageLevel(StorageLevel.DISK)
         .build())
       .withTransport(Transport.build(4, sslConfig))
-      .withElectionTimeout(Duration.ofSeconds(10))
+      .withElectionTimeout(Duration.ofSeconds(15))
       .withHeartbeatInterval(Duration.ofSeconds(1))
-      .withSessionTimeout(Duration.ofSeconds(15))
+      .withSessionTimeout(Duration.ofSeconds(30))
       .build()
     Serializers.register(server.serializer)
     server

--- a/transactor/src/main/scala/io/mediachain/copycat/Server.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/Server.scala
@@ -32,7 +32,7 @@ object Server {
       .withTransport(Transport.build(4, sslConfig))
       .withElectionTimeout(Duration.ofSeconds(10))
       .withHeartbeatInterval(Duration.ofSeconds(1))
-      .withSessionTimeout(Duration.ofSeconds(10))
+      .withSessionTimeout(Duration.ofSeconds(15))
       .build()
     Serializers.register(server.serializer)
     server

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -184,17 +184,13 @@ object StateMachine {
         
     // Snapshottable
     override def install(reader: SnapshotReader) {
-      //state = reader.readObject()
-      val ser = new Serializers.JournalStateSerializer
-      state = ser.read(reader)
+      state = reader.readObject()
     }
     
     override def snapshot(writer: SnapshotWriter) {
       logger.info(s"Taking JournalState snapshot at ${state.seqno}")
       val begin = System.currentTimeMillis
-      // writer.writeObject(state)
-      val ser = new Serializers.JournalStateSerializer
-      ser.write(writer, state)
+      writer.writeObject(state)
       val end = System.currentTimeMillis
       val delta = (end - begin) / 1000.0
       logger.info(s"JournalState snapshot took ${delta}s")

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -188,7 +188,12 @@ object StateMachine {
     }
     
     override def snapshot(writer: SnapshotWriter) {
+      logger.info(s"Taking JournalState snapshot at ${state.seqno}")
+      val begin = System.currentTimeMillis
       writer.writeObject(state)
+      val end = System.currentTimeMillis
+      val delta = (end - begin) / 1000.0
+      logger.info(s"JournalState snapshot took ${delta}s")
     }
     
     // Session Listener

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -184,13 +184,17 @@ object StateMachine {
         
     // Snapshottable
     override def install(reader: SnapshotReader) {
-      state = reader.readObject()
+      //state = reader.readObject()
+      val ser = new Serializers.JournalStateSerializer
+      state = ser.read(reader)
     }
     
     override def snapshot(writer: SnapshotWriter) {
       logger.info(s"Taking JournalState snapshot at ${state.seqno}")
       val begin = System.currentTimeMillis
-      writer.writeObject(state)
+      //writer.writeObject(state)
+      val ser = new Serializers.JournalStateSerializer
+      ser.write(writer, state)
       val end = System.currentTimeMillis
       val delta = (end - begin) / 1000.0
       logger.info(s"JournalState snapshot took ${delta}s")

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -184,17 +184,13 @@ object StateMachine {
         
     // Snapshottable
     override def install(reader: SnapshotReader) {
-      //state = reader.readObject()
-      val ser = new Serializers.JournalStateSerializer
-      state = ser.read(reader)
+      state = reader.readObject()
     }
     
     override def snapshot(writer: SnapshotWriter) {
       logger.info(s"Taking JournalState snapshot at ${state.seqno}")
       val begin = System.currentTimeMillis
-      //writer.writeObject(state)
-      val ser = new Serializers.JournalStateSerializer
-      ser.write(writer, state)
+      writer.writeObject(state)
       val end = System.currentTimeMillis
       val delta = (end - begin) / 1000.0
       logger.info(s"JournalState snapshot took ${delta}s")

--- a/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/StateMachine.scala
@@ -184,13 +184,17 @@ object StateMachine {
         
     // Snapshottable
     override def install(reader: SnapshotReader) {
-      state = reader.readObject()
+      //state = reader.readObject()
+      val ser = new Serializers.JournalStateSerializer
+      state = ser.read(reader)
     }
     
     override def snapshot(writer: SnapshotWriter) {
       logger.info(s"Taking JournalState snapshot at ${state.seqno}")
       val begin = System.currentTimeMillis
-      writer.writeObject(state)
+      // writer.writeObject(state)
+      val ser = new Serializers.JournalStateSerializer
+      ser.write(writer, state)
       val end = System.currentTimeMillis
       val delta = (end - begin) / 1000.0
       logger.info(s"JournalState snapshot took ${delta}s")

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -271,10 +271,10 @@ extends ClientStateListener with JournalListener {
     val block = Await.result(client.currentBlock, Duration.Inf)
     if (state.isEmpty) {
       setCurrentBlock(block)
-    } else if (block.chain == state.blockchain) {
-      extendCurrentBlock(block)
     } else if (block.index < state.index) {
       logger.warn(s"Cluster replayed STALE BLOCK ${block.index}; current index is ${state.index}")
+    } else if (block.chain == state.blockchain) {
+      extendCurrentBlock(block)
     } else if (block.chain.isEmpty) {
       throw new RuntimeException("PANIC: Blockchain divergence detected")
     } else {

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -227,6 +227,7 @@ extends ClientStateListener with JournalListener {
       : List[JournalBlock]
       = {
         val block = getBlock(ref)
+        logger.info(s"Fetched block ${ref} -> ${block.index} ${block.chain}")
         if (block.chain == state.blockchain) {
           block :: blocks
         } else if (block.chain.isEmpty) {
@@ -278,6 +279,7 @@ extends ClientStateListener with JournalListener {
     } else if (block.chain.isEmpty) {
       throw new RuntimeException("PANIC: Blockchain divergence detected")
     } else {
+      logger.info(s"Resyncing blockchain ${state.index} ${state.blockchain} -> ${block.index} ${block.chain}")
       val xblocks = fetchBlocks(block.chain)
       extendCurrentBlock(xblocks.head)
       xblocks.tail.foreach(setCurrentBlock(_))

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -273,6 +273,8 @@ extends ClientStateListener with JournalListener {
       setCurrentBlock(block)
     } else if (block.chain == state.blockchain) {
       extendCurrentBlock(block)
+    } else if (block.index < state.index) {
+      logger.warn(s"Cluster replayed STALE BLOCK ${block.index}; current index is ${state.index}")
     } else if (block.chain.isEmpty) {
       throw new RuntimeException("PANIC: Blockchain divergence detected")
     } else {

--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -230,7 +230,7 @@ extends ClientStateListener with JournalListener {
         logger.info(s"Fetched block ${ref} -> ${block.index} ${block.chain}")
         if (block.chain == state.blockchain) {
           block :: blocks
-        } else if (block.chain.isEmpty) {
+        } else if (block.chain.isEmpty || block.index < state.index) {
           throw new RuntimeException("PANIC: Blockchain divergence detected")
         } else {
           loop(block.chain.get, block :: blocks)


### PR DESCRIPTION
Increasing the election timeout seems to alleviate  the conditions for blockchain divergence.

Experiments were run to determine if the snapshot time indeed exceeds the ~3s range precipitating the problems. Indeed the case, snapshot times of up to 8s were measured, exceeding the election timeout of 3.

An experimental custom serializater is added for snapshots, but it is still slower than pojo serialization and hence inactive.
