### PR TITLE
fix race condition in client ip logger

### DIFF
--- a/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
+++ b/transactor/src/main/scala/io/mediachain/copycat/TransactorService.scala
@@ -546,9 +546,8 @@ object TransactorService {
         call.attributes().get(ServerCall.REMOTE_ADDR_KEY) match {
           case inet: InetSocketAddress =>
             val address = inet.getAddress
-            if (!uniqueClientAddresses.contains(address)) {
+            if (uniqueClientAddresses.add(address)) {
               logger.info(address.toString)
-              uniqueClientAddresses.add(address)
             }
           case nonInet =>
             // should only be hit during in-process transport (unit tests, etc)


### PR DESCRIPTION
`.add` is atomic, so don't check if the address is present in the set first.
